### PR TITLE
fix: filter inherited Python env vars to prevent conflicts

### DIFF
--- a/box/box.go
+++ b/box/box.go
@@ -93,11 +93,17 @@ func (b *Box) logUvEnvironmentVariables() {
 }
 
 func (b *Box) commandsEnvironment() ([]string, error) {
-	// Get uv environment variables
+	// Get uv environment variables for this box
 	env := b.uvEnvironmentVariables()
 
-	// Add current user environment variables
-	env = append(env, os.Environ()...)
+	// Add current user environment variables, filtering out any Python-related
+	// environment variables that could cause conflicts when a uvbox binary
+	// runs another uvbox binary
+	userEnv, filteredKeys := filterOutPythonEnvironmentVariables(os.Environ())
+	if len(filteredKeys) > 0 {
+		logger.Debug("Filtered out inherited Python environment variables", logger.ArgsFromMap(map[string]any{"filteredKeys": filteredKeys}))
+	}
+	env = append(env, userEnv...)
 
 	// Add SSL_CERT_FILE and REQUESTS_CA_BUNDLE if asked by the user
 	if b.CertificatesBundle != "" {
@@ -185,4 +191,28 @@ func environListAsMap(environment []string) map[string]any {
 		}
 	}
 	return envMap
+}
+
+// filterOutPythonEnvironmentVariables removes environment variables that could
+// cause conflicts when a uvbox binary runs another uvbox binary.
+// Filtered variables:
+// - UV_* : uv tool configuration (each uvbox binary has its own)
+// - VIRTUAL_ENV : virtual environment path (uvbox uses its own isolated env)
+// - PYTHONPATH : Python module search path (uvbox should use its own packages)
+func filterOutPythonEnvironmentVariables(env []string) (filtered []string, removed []string) {
+	filtered = []string{}
+	removed = []string{}
+	for _, e := range env {
+		key := e
+		if idx := strings.Index(e, "="); idx != -1 {
+			key = e[:idx]
+		}
+
+		if strings.HasPrefix(key, "UV_") || key == "VIRTUAL_ENV" || key == "PYTHONPATH" {
+			removed = append(removed, key)
+		} else {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered, removed
 }

--- a/box/box_test.go
+++ b/box/box_test.go
@@ -157,3 +157,357 @@ func TestCanUninstallWithoutPriorInstallWithoutCrash(t *testing.T) {
 		t.Fatalf("could not uninstall box: %v", err)
 	}
 }
+
+// Test filterOutPythonEnvironmentVariables filters UV_* variables
+func TestFilterOutPythonEnvironmentVariablesFiltersUvVariables(t *testing.T) {
+	input := []string{
+		"UV_CACHE_DIR=/some/path",
+		"UV_TOOL_DIR=/another/path",
+		"UV_NO_CONFIG=1",
+		"UV_PYTHON=3.12",
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+	}
+
+	filtered, removed := filterOutPythonEnvironmentVariables(input)
+
+	// Check filtered contains non-UV variables
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 filtered variables, got %d: %v", len(filtered), filtered)
+	}
+	if filtered[0] != "PATH=/usr/bin" || filtered[1] != "HOME=/home/user" {
+		t.Fatalf("expected PATH and HOME to be preserved, got: %v", filtered)
+	}
+
+	// Check removed contains UV variables
+	if len(removed) != 4 {
+		t.Fatalf("expected 4 removed variables, got %d: %v", len(removed), removed)
+	}
+	expectedRemoved := map[string]bool{
+		"UV_CACHE_DIR": true,
+		"UV_TOOL_DIR":  true,
+		"UV_NO_CONFIG": true,
+		"UV_PYTHON":    true,
+	}
+	for _, key := range removed {
+		if !expectedRemoved[key] {
+			t.Fatalf("unexpected removed key: %s", key)
+		}
+	}
+}
+
+// Test filterOutPythonEnvironmentVariables filters VIRTUAL_ENV
+func TestFilterOutPythonEnvironmentVariablesFiltersVirtualEnv(t *testing.T) {
+	input := []string{
+		"VIRTUAL_ENV=/home/user/.venv",
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+	}
+
+	filtered, removed := filterOutPythonEnvironmentVariables(input)
+
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 filtered variables, got %d: %v", len(filtered), filtered)
+	}
+	if len(removed) != 1 || removed[0] != "VIRTUAL_ENV" {
+		t.Fatalf("expected VIRTUAL_ENV to be removed, got: %v", removed)
+	}
+}
+
+// Test filterOutPythonEnvironmentVariables filters PYTHONPATH
+func TestFilterOutPythonEnvironmentVariablesFiltersPythonpath(t *testing.T) {
+	input := []string{
+		"PYTHONPATH=/home/user/lib:/home/user/packages",
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+	}
+
+	filtered, removed := filterOutPythonEnvironmentVariables(input)
+
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 filtered variables, got %d: %v", len(filtered), filtered)
+	}
+	if len(removed) != 1 || removed[0] != "PYTHONPATH" {
+		t.Fatalf("expected PYTHONPATH to be removed, got: %v", removed)
+	}
+}
+
+// Test filterOutPythonEnvironmentVariables filters all Python-related variables together
+func TestFilterOutPythonEnvironmentVariablesFiltersAllPythonVariables(t *testing.T) {
+	input := []string{
+		"UV_CACHE_DIR=/cache",
+		"UV_TOOL_DIR=/tools",
+		"UV_TOOL_BIN_DIR=/tools-bin",
+		"VIRTUAL_ENV=/home/user/.venv",
+		"PYTHONPATH=/home/user/lib",
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+		"LANG=en_US.UTF-8",
+	}
+
+	filtered, removed := filterOutPythonEnvironmentVariables(input)
+
+	// Check filtered preserves non-Python variables
+	if len(filtered) != 3 {
+		t.Fatalf("expected 3 filtered variables, got %d: %v", len(filtered), filtered)
+	}
+	expectedFiltered := []string{"PATH=/usr/bin", "HOME=/home/user", "LANG=en_US.UTF-8"}
+	for i, expected := range expectedFiltered {
+		if filtered[i] != expected {
+			t.Fatalf("expected filtered[%d] = %s, got %s", i, expected, filtered[i])
+		}
+	}
+
+	// Check removed contains all Python-related variables
+	if len(removed) != 5 {
+		t.Fatalf("expected 5 removed variables, got %d: %v", len(removed), removed)
+	}
+	expectedRemoved := map[string]bool{
+		"UV_CACHE_DIR":    true,
+		"UV_TOOL_DIR":     true,
+		"UV_TOOL_BIN_DIR": true,
+		"VIRTUAL_ENV":     true,
+		"PYTHONPATH":      true,
+	}
+	for _, key := range removed {
+		if !expectedRemoved[key] {
+			t.Fatalf("unexpected removed key: %s", key)
+		}
+	}
+}
+
+// Test filterOutPythonEnvironmentVariables with empty input
+func TestFilterOutPythonEnvironmentVariablesEmptyInput(t *testing.T) {
+	input := []string{}
+
+	filtered, removed := filterOutPythonEnvironmentVariables(input)
+
+	if len(filtered) != 0 {
+		t.Fatalf("expected 0 filtered variables, got %d", len(filtered))
+	}
+	if len(removed) != 0 {
+		t.Fatalf("expected 0 removed variables, got %d", len(removed))
+	}
+}
+
+// Test filterOutPythonEnvironmentVariables when nothing needs filtering
+func TestFilterOutPythonEnvironmentVariablesNoMatches(t *testing.T) {
+	input := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+		"LANG=en_US.UTF-8",
+		"TERM=xterm-256color",
+	}
+
+	filtered, removed := filterOutPythonEnvironmentVariables(input)
+
+	if len(filtered) != 4 {
+		t.Fatalf("expected 4 filtered variables, got %d: %v", len(filtered), filtered)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("expected 0 removed variables, got %d: %v", len(removed), removed)
+	}
+	for i, expected := range input {
+		if filtered[i] != expected {
+			t.Fatalf("expected filtered[%d] = %s, got %s", i, expected, filtered[i])
+		}
+	}
+}
+
+// Test filterOutPythonEnvironmentVariables does not filter variables that start with UV but not UV_
+func TestFilterOutPythonEnvironmentVariablesDoesNotFilterUvWithoutUnderscore(t *testing.T) {
+	input := []string{
+		"UVBOX_DEBUG=1",
+		"UVISION=enabled",
+		"UV_CACHE_DIR=/cache",
+		"PATH=/usr/bin",
+	}
+
+	filtered, removed := filterOutPythonEnvironmentVariables(input)
+
+	// UVBOX_DEBUG and UVISION should be preserved (they don't start with UV_)
+	if len(filtered) != 3 {
+		t.Fatalf("expected 3 filtered variables, got %d: %v", len(filtered), filtered)
+	}
+	if filtered[0] != "UVBOX_DEBUG=1" || filtered[1] != "UVISION=enabled" || filtered[2] != "PATH=/usr/bin" {
+		t.Fatalf("expected UVBOX_DEBUG, UVISION, and PATH to be preserved, got: %v", filtered)
+	}
+
+	// Only UV_CACHE_DIR should be removed
+	if len(removed) != 1 || removed[0] != "UV_CACHE_DIR" {
+		t.Fatalf("expected only UV_CACHE_DIR to be removed, got: %v", removed)
+	}
+}
+
+// Test filterOutPythonEnvironmentVariables handles variables without values
+func TestFilterOutPythonEnvironmentVariablesHandlesEmptyValues(t *testing.T) {
+	input := []string{
+		"UV_CACHE_DIR=",
+		"VIRTUAL_ENV=",
+		"PATH=",
+	}
+
+	filtered, removed := filterOutPythonEnvironmentVariables(input)
+
+	if len(filtered) != 1 || filtered[0] != "PATH=" {
+		t.Fatalf("expected PATH= to be preserved, got: %v", filtered)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("expected 2 removed variables, got %d: %v", len(removed), removed)
+	}
+}
+
+// Test commandsEnvironment filters inherited UV_* variables
+func TestCommandsEnvironmentFiltersInheritedUvVariables(t *testing.T) {
+	homePath := testDirectory(t)
+	defer os.RemoveAll(homePath)
+
+	// Set some UV_* environment variables that simulate a parent uvbox binary
+	// t.Setenv automatically restores the original value after the test
+	t.Setenv("UV_CACHE_DIR", "/parent/cache")
+	t.Setenv("UV_TOOL_DIR", "/parent/tools")
+	t.Setenv("UV_TOOL_BIN_DIR", "/parent/tools-bin")
+	t.Setenv("UV_PYTHON_INSTALL_DIR", "/parent/python")
+	t.Setenv("UV_NO_CONFIG", "1")
+
+	box := GetBox("childIdentifier", "childPackage", []string{}, homePath)
+	env, err := box.commandsEnvironment()
+	if err != nil {
+		t.Fatalf("could not get commands environment: %v", err)
+	}
+
+	// Build a map for easy lookup
+	envMap := make(map[string]string)
+	for _, e := range env {
+		if idx := indexOf(e, "="); idx != -1 {
+			key := e[:idx]
+			value := e[idx+1:]
+			// Only keep the first occurrence (which should be the box's own variables)
+			if _, exists := envMap[key]; !exists {
+				envMap[key] = value
+			}
+		}
+	}
+
+	// Check that the box's OWN UV_* variables are present (not the parent's)
+	expectedCacheDir := filepath.Join(homePath, "uvbox", "childIdentifier", "cache")
+	if envMap["UV_CACHE_DIR"] != expectedCacheDir {
+		t.Fatalf("expected UV_CACHE_DIR=%s, got %s", expectedCacheDir, envMap["UV_CACHE_DIR"])
+	}
+
+	expectedToolDir := filepath.Join(homePath, "uvbox", "childIdentifier", "tools")
+	if envMap["UV_TOOL_DIR"] != expectedToolDir {
+		t.Fatalf("expected UV_TOOL_DIR=%s, got %s", expectedToolDir, envMap["UV_TOOL_DIR"])
+	}
+
+	// Verify the parent's values are NOT present anywhere in the env list
+	for _, e := range env {
+		if e == "UV_CACHE_DIR=/parent/cache" {
+			t.Fatal("parent's UV_CACHE_DIR should have been filtered out")
+		}
+		if e == "UV_TOOL_DIR=/parent/tools" {
+			t.Fatal("parent's UV_TOOL_DIR should have been filtered out")
+		}
+	}
+}
+
+// Test commandsEnvironment filters VIRTUAL_ENV and PYTHONPATH
+func TestCommandsEnvironmentFiltersVirtualEnvAndPythonpath(t *testing.T) {
+	homePath := testDirectory(t)
+	defer os.RemoveAll(homePath)
+
+	// Set VIRTUAL_ENV and PYTHONPATH that simulate a parent environment
+	// t.Setenv automatically restores the original value after the test
+	t.Setenv("VIRTUAL_ENV", "/parent/.venv")
+	t.Setenv("PYTHONPATH", "/parent/lib:/parent/packages")
+
+	box := GetBox("childIdentifier", "childPackage", []string{}, homePath)
+	env, err := box.commandsEnvironment()
+	if err != nil {
+		t.Fatalf("could not get commands environment: %v", err)
+	}
+
+	// Verify VIRTUAL_ENV and PYTHONPATH are NOT present in the environment
+	for _, e := range env {
+		if e == "VIRTUAL_ENV=/parent/.venv" {
+			t.Fatal("VIRTUAL_ENV should have been filtered out")
+		}
+		if e == "PYTHONPATH=/parent/lib:/parent/packages" {
+			t.Fatal("PYTHONPATH should have been filtered out")
+		}
+	}
+}
+
+// Test commandsEnvironment preserves non-Python environment variables
+func TestCommandsEnvironmentPreservesNonPythonVariables(t *testing.T) {
+	homePath := testDirectory(t)
+	defer os.RemoveAll(homePath)
+
+	// Set some environment variables that should be preserved
+	// t.Setenv automatically restores the original value after the test
+	testValue := "test-value-12345"
+	t.Setenv("MY_CUSTOM_VAR", testValue)
+
+	box := GetBox("testIdentifier", "testPackage", []string{}, homePath)
+	env, err := box.commandsEnvironment()
+	if err != nil {
+		t.Fatalf("could not get commands environment: %v", err)
+	}
+
+	// Check that MY_CUSTOM_VAR is present
+	found := false
+	for _, e := range env {
+		if e == "MY_CUSTOM_VAR="+testValue {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("MY_CUSTOM_VAR should have been preserved in the environment")
+	}
+}
+
+// Test commandsEnvironment includes box's UV extra environment variables
+func TestCommandsEnvironmentIncludesUvExtraEnviron(t *testing.T) {
+	homePath := testDirectory(t)
+	defer os.RemoveAll(homePath)
+
+	uvExtraEnviron := []string{
+		"UV_PYTHON=3.12",
+		"UV_INDEX=https://custom.pypi.org/simple",
+	}
+
+	box := GetBox("testIdentifier", "testPackage", uvExtraEnviron, homePath)
+	env, err := box.commandsEnvironment()
+	if err != nil {
+		t.Fatalf("could not get commands environment: %v", err)
+	}
+
+	// Check that UV extra environ variables are present
+	foundPython := false
+	foundIndex := false
+	for _, e := range env {
+		if e == "UV_PYTHON=3.12" {
+			foundPython = true
+		}
+		if e == "UV_INDEX=https://custom.pypi.org/simple" {
+			foundIndex = true
+		}
+	}
+	if !foundPython {
+		t.Fatal("UV_PYTHON from uvExtraEnviron should be present")
+	}
+	if !foundIndex {
+		t.Fatal("UV_INDEX from uvExtraEnviron should be present")
+	}
+}
+
+// Helper function to find index of substring
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
When a uvbox-built binary runs another uvbox-built binary, the parent's UV_*, VIRTUAL_ENV, and PYTHONPATH environment variables were being inherited, causing conflicts with the child's intended configuration.

This change filters out these variables from the inherited environment before setting the box's own configuration, ensuring proper isolation between nested uvbox binaries.

Filtered variables:
- UV_* : uv tool configuration (each uvbox binary has its own)
- VIRTUAL_ENV : virtual environment path (uvbox uses its own isolated env)
- PYTHONPATH : Python module search path (uvbox should use its own packages)