### PR TITLE
feat: add 'uvbox git' subcommand for git repository sources (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 box/uvbox.toml
 box/wheels
+box/git_source.txt
 
 boxer/boxes
 boxer/boxer

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ## Features
 
-- **Package from PyPI or Wheels** — Install your application from package indexes or choose to bundle local wheel files
+- **Package from PyPI, Wheels, or Git** — Install your application from package indexes, bundle local wheel files, or fetch from a git repository
 - **True Cross-Compilation** — Build binaries for Linux, macOS, and Windows (AMD64/ARM64) from any platform in seconds
 - **Auto-Updates** — Built-in version checking and self-update/fallback capabilities for your binaries
 - **Dependency Freezing** — Use constraints files to ensure reproducible installations
@@ -115,6 +115,42 @@ Package local wheel files instead of installing from PyPI:
 ```bash
 uvbox wheel --config uvbox.toml ./my-app.whl
 ```
+
+### Build from a Git Repository
+
+Package an application from a git repository that isn't published to PyPI:
+
+```bash
+# Default branch
+uvbox git git+https://github.com/org/repo --config uvbox.toml
+
+# Specific tag
+uvbox git git+https://github.com/org/repo@v1.0.0
+
+# Specific branch
+uvbox git git+https://github.com/org/repo@main
+
+# Specific commit
+uvbox git git+https://github.com/org/repo@abc123
+
+# SSH (uses your local git credentials)
+uvbox git git+ssh://git@github.com/org/private-repo
+```
+
+The git spec is passed through to `uv tool install --from` verbatim at runtime
+on the end-user's machine. `uvbox` itself never clones the repository at build
+time — the clone happens on first run of the generated binary. This means you
+can build binaries for a private repo without providing credentials to the
+build machine; the end user's local git/ssh setup handles authentication.
+
+**Behavior of `[package.version]` for git builds:**
+- `static` and `dynamic` are ignored for install resolution — the git ref in
+  the spec is the source of truth.
+- `auto-update = true` re-runs `uv tool install --from <spec> --upgrade` on
+  every invocation, giving you the "fresh dependencies every run" behavior
+  equivalent to `pycrucible`'s `delete_after_run = true`.
+- Leave `dynamic` unset when tracking a moving branch; setting it will disable
+  the always-update behavior.
 
 ## Configuration
 

--- a/box/box_package.go
+++ b/box/box_package.go
@@ -157,6 +157,9 @@ func (b *Box) InstalledPackagePath() (string, error) {
 }
 
 func (b *Box) uvToolInstall(packageVersion, constraintsFile string) error {
+	if GIT_SOURCE != "" {
+		return b.uvToolInstallGit(constraintsFile)
+	}
 	if INSTALL_WHEELS == "no" {
 		return b.uvToolInstallPypi(packageVersion, constraintsFile)
 	} else {

--- a/box/box_package_git.go
+++ b/box/box_package_git.go
@@ -1,0 +1,7 @@
+package main
+
+// GIT_SOURCE is populated via ldflags at build time (-X main.GIT_SOURCE=git+...)
+// when the binary is produced by `uvbox git <spec>`. When empty, the binary was
+// produced by `uvbox pypi` or `uvbox wheel` and the runtime install path skips
+// the git dispatch entirely.
+var GIT_SOURCE = ""

--- a/box/box_package_git.go
+++ b/box/box_package_git.go
@@ -5,3 +5,27 @@ package main
 // produced by `uvbox pypi` or `uvbox wheel` and the runtime install path skips
 // the git dispatch entirely.
 var GIT_SOURCE = ""
+
+// buildUvToolInstallFromArgs constructs the command-line arguments for
+// `uv tool install --from <gitSource> <packageName> --upgrade`, optionally
+// appending `--with-requirements <constraintsFile>`. Pure function: no
+// side effects, easy to unit-test.
+//
+// The `--upgrade` flag is always included for git sources because there is
+// no "pinned version" concept — every install/update must re-resolve the ref.
+func buildUvToolInstallFromArgs(uvPath, gitSource, packageName, constraintsFile string) []string {
+	args := []string{
+		uvPath,
+		"--quiet",
+		"tool",
+		"install",
+		"--from",
+		gitSource,
+		packageName,
+		"--upgrade",
+	}
+	if constraintsFile != "" {
+		args = append(args, "--with-requirements", constraintsFile)
+	}
+	return args
+}

--- a/box/box_package_git.go
+++ b/box/box_package_git.go
@@ -1,16 +1,32 @@
 package main
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
-// GIT_SOURCE is populated via ldflags at build time (-X main.GIT_SOURCE=git+...)
-// when the binary is produced by `uvbox git <spec>`. When empty, the binary was
-// produced by `uvbox pypi` or `uvbox wheel` and the runtime install path skips
-// the git dispatch entirely.
-var GIT_SOURCE = ""
+// gitSourceContent is the raw content of git_source.txt, embedded at build
+// time. For `uvbox git <spec>` builds, boxer writes the git spec into this
+// file before invoking `go build`. For pypi/wheel builds, the file exists
+// but is empty — matching the committed placeholder in box/git_source.txt.
+//
+// We use a file-embed instead of an ldflag (-X main.GIT_SOURCE=...) because
+// Go's GOFLAGS parser does not support spaces inside flag values, and the
+// boxer build path routes ldflags through GOFLAGS for Windows compatibility
+// (see issue #7). Passing `-X main.FOO=bar` via GOFLAGS fails to parse.
+//
+//go:embed git_source.txt
+var gitSourceContent string
+
+// GIT_SOURCE is the embedded git source string (e.g., "git+https://github.com/org/repo@main")
+// for binaries produced by `uvbox git <spec>`. It is empty for pypi/wheel
+// builds, in which case the runtime install path skips the git dispatch
+// entirely. Trimmed on init to tolerate trailing whitespace/newlines in
+// the embedded file.
+var GIT_SOURCE = strings.TrimSpace(gitSourceContent)
 
 // buildUvToolInstallFromArgs constructs the command-line arguments for
 // `uv tool install --from <gitSource> <packageName> --upgrade`, optionally

--- a/box/box_package_git.go
+++ b/box/box_package_git.go
@@ -1,5 +1,11 @@
 package main
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
 // GIT_SOURCE is populated via ldflags at build time (-X main.GIT_SOURCE=git+...)
 // when the binary is produced by `uvbox git <spec>`. When empty, the binary was
 // produced by `uvbox pypi` or `uvbox wheel` and the runtime install path skips
@@ -28,4 +34,40 @@ func buildUvToolInstallFromArgs(uvPath, gitSource, packageName, constraintsFile 
 		args = append(args, "--with-requirements", constraintsFile)
 	}
 	return args
+}
+
+// uvToolInstallGit installs the package from the embedded GIT_SOURCE via
+// `uv tool install --from <GIT_SOURCE> <PackageName> --upgrade`. Mirrors
+// uvToolInstallPypi and uvToolInstallWheels in shape and error handling,
+// but uses --from to delegate git-spec parsing to uv itself.
+func (b *Box) uvToolInstallGit(constraintsFile string) error {
+	logger.Debug("Installing package from git",
+		logger.Args("name", b.PackageName, "source", GIT_SOURCE, "constraintsFile", constraintsFile))
+
+	uv, err := b.InstalledUvExecutablePath()
+	if err != nil {
+		return fmt.Errorf("could not find uv executable: %w", err)
+	}
+
+	commandArgs := buildUvToolInstallFromArgs(uv, GIT_SOURCE, b.PackageName, constraintsFile)
+
+	env, err := b.commandsEnvironment()
+	if err != nil {
+		return fmt.Errorf("could not get uv environment variables: %w", err)
+	}
+
+	cmd := exec.Command(commandArgs[0], commandArgs[1:]...)
+	cmd.Env = env
+	cmd.Stderr = os.Stderr
+	if debugEnabled() || traceEnabled() {
+		cmd.Stdout = os.Stdout
+	}
+	logger.Trace("Running", logger.Args("command", commandArgs, "env", env))
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run command %v: %w", commandArgs, err)
+	}
+
+	logger.Debug("Installed", logger.Args("package", b.PackageName))
+	return nil
 }

--- a/box/box_package_git_test.go
+++ b/box/box_package_git_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildUvToolInstallFromArgs_Minimal(t *testing.T) {
+	got := buildUvToolInstallFromArgs("/path/to/uv", "git+https://github.com/org/repo", "mypkg", "")
+	want := []string{
+		"/path/to/uv",
+		"--quiet",
+		"tool",
+		"install",
+		"--from",
+		"git+https://github.com/org/repo",
+		"mypkg",
+		"--upgrade",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildUvToolInstallFromArgs minimal = %v, want %v", got, want)
+	}
+}
+
+func TestBuildUvToolInstallFromArgs_WithRef(t *testing.T) {
+	got := buildUvToolInstallFromArgs("uv", "git+https://github.com/org/repo@v1.0.0", "mypkg", "")
+	want := []string{
+		"uv",
+		"--quiet",
+		"tool",
+		"install",
+		"--from",
+		"git+https://github.com/org/repo@v1.0.0",
+		"mypkg",
+		"--upgrade",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildUvToolInstallFromArgs with ref = %v, want %v", got, want)
+	}
+}
+
+func TestBuildUvToolInstallFromArgs_WithConstraints(t *testing.T) {
+	got := buildUvToolInstallFromArgs("uv", "git+https://github.com/org/repo", "mypkg", "/tmp/constraints.txt")
+	want := []string{
+		"uv",
+		"--quiet",
+		"tool",
+		"install",
+		"--from",
+		"git+https://github.com/org/repo",
+		"mypkg",
+		"--upgrade",
+		"--with-requirements",
+		"/tmp/constraints.txt",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildUvToolInstallFromArgs with constraints = %v, want %v", got, want)
+	}
+}

--- a/box/config.go
+++ b/box/config.go
@@ -70,6 +70,9 @@ func (c Configuration) PanicIfInvalid() {
 func (c Configuration) ComputeIdentifier() string {
 	hasher := crypto.SHA1.New()
 	textToHash := fmt.Sprintf("%s%s%s%t", c.Package.Name, c.Package.Script, c.Package.Version.Static, c.AutoUpdateEnabled())
+	if GIT_SOURCE != "" {
+		textToHash += GIT_SOURCE
+	}
 	_, err := io.WriteString(hasher, textToHash)
 	if err != nil {
 		logger.Fatal("Failed to hash script value", logger.Args("error", err))

--- a/box/config_identifier_test.go
+++ b/box/config_identifier_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+)
+
+// makeTestConfig returns a Configuration representative of a typical pypi build.
+func makeTestConfig() Configuration {
+	return Configuration{
+		Package: PackageConfiguration{
+			Name:   "my-package",
+			Script: "my-script",
+			Version: PackageVersionConfiguration{
+				AutoUpdate: true,
+				Static:     "1.0.0",
+			},
+		},
+	}
+}
+
+// TestComputeIdentifier_StableForPypi is the regression guard for
+// "additive only, don't affect existing features". The expected value
+// was captured from the pre-git-support version of ComputeIdentifier
+// and must not change when GIT_SOURCE is empty.
+func TestComputeIdentifier_StableForPypi(t *testing.T) {
+	// Ensure GIT_SOURCE is empty for this test (it's the default, but be explicit).
+	origGitSource := GIT_SOURCE
+	GIT_SOURCE = ""
+	t.Cleanup(func() { GIT_SOURCE = origGitSource })
+
+	cfg := makeTestConfig()
+	got := cfg.ComputeIdentifier()
+	want := "my-package-30bb8d607d1417531f6df2a733f8ad02439c2b3a"
+	if got != want {
+		t.Fatalf("ComputeIdentifier() = %q, want %q (regression: existing pypi/wheel binaries must hash identically)", got, want)
+	}
+}
+
+func TestComputeIdentifier_DiffersByGitSource(t *testing.T) {
+	cfg := makeTestConfig()
+
+	origGitSource := GIT_SOURCE
+	t.Cleanup(func() { GIT_SOURCE = origGitSource })
+
+	GIT_SOURCE = ""
+	pypiID := cfg.ComputeIdentifier()
+
+	GIT_SOURCE = "git+https://github.com/org/repo"
+	gitID := cfg.ComputeIdentifier()
+
+	if pypiID == gitID {
+		t.Fatalf("expected git build to produce a different identifier than pypi build, both got %q", pypiID)
+	}
+}
+
+func TestComputeIdentifier_DiffersByGitRef(t *testing.T) {
+	cfg := makeTestConfig()
+
+	origGitSource := GIT_SOURCE
+	t.Cleanup(func() { GIT_SOURCE = origGitSource })
+
+	GIT_SOURCE = "git+https://github.com/org/repo@main"
+	mainID := cfg.ComputeIdentifier()
+
+	GIT_SOURCE = "git+https://github.com/org/repo@v1.0.0"
+	tagID := cfg.ComputeIdentifier()
+
+	if mainID == tagID {
+		t.Fatalf("expected different git refs to produce different identifiers, both got %q", mainID)
+	}
+}

--- a/box/generate.go
+++ b/box/generate.go
@@ -12,6 +12,7 @@ var CONFIGURATION_FILENAME = "uvbox.toml"
 var CERTIFICATES_BUNDLE_FILENAME = "ca-bundle.crt"
 var WHEELS_FOLDER = "wheels"
 var WHEELS_PLACEHOLDER = filepath.Join(WHEELS_FOLDER, "placeholder")
+var GIT_SOURCE_FILENAME = "git_source.txt"
 
 func deleteIfExists(filename string) {
 	if _, err := os.Stat(filename); err != nil && os.IsNotExist(err) {
@@ -50,4 +51,8 @@ func main() {
 
 	// Generate wheels folder placeholder
 	generateEmptyFileIfMissing(WHEELS_PLACEHOLDER)
+
+	// Generate empty git_source.txt placeholder (populated at uvbox-build
+	// time by boxer's writeGitSourceFile when `uvbox git <spec>` is used).
+	generateEmptyFileIfMissing(GIT_SOURCE_FILENAME)
 }

--- a/boxer/git.go
+++ b/boxer/git.go
@@ -2,33 +2,48 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
 // buildGoBuildLdflags constructs the ldflags string passed to `go build`
 // via the `GOFLAGS=-ldflags=...` environment variable. Pure function:
 // no side effects, no package-level state reads, so it can be unit-tested
-// without invoking go build. The arguments mirror the inputs the caller
-// has at the point of invocation (gitSource CLI arg, WheelsToEmbed list).
+// without invoking go build.
 //
 // Behavior:
 //   - Always includes "-s -w" to strip debug info.
 //   - If wheels are embedded, adds "-X main.INSTALL_WHEELS=yes" (unchanged
 //     from the pre-git-support behavior — regression test locks this in).
-//   - If a git source is set, adds "-X main.GIT_SOURCE=<spec>".
 //
-// The git and wheel flags are independent: validateGitSource + CLI command
-// separation ensure only one of the two is actually set in practice. This
-// function does not enforce mutual exclusion; the CLI layer does.
-func buildGoBuildLdflags(gitSource string, wheelsToEmbed []string) string {
+// Note on git source: unlike wheels, the git source is NOT injected via
+// ldflags. Go's GOFLAGS parser (strings.Fields) does not support spaces
+// inside flag values, so `-X main.GIT_SOURCE=<spec>` breaks parsing for
+// any ldflag string containing `-X`. Instead, the git source is written
+// to box/git_source.txt and embedded via //go:embed — see
+// writeGitSourceFile below and box/box_package_git.go.
+func buildGoBuildLdflags(wheelsToEmbed []string) string {
 	ldflags := "-s -w"
 	if len(wheelsToEmbed) > 0 {
 		ldflags += " -X main.INSTALL_WHEELS=yes"
 	}
-	if gitSource != "" {
-		ldflags += fmt.Sprintf(" -X main.GIT_SOURCE=%s", gitSource)
-	}
 	return ldflags
+}
+
+// writeGitSourceFile writes the provided git source string to
+// <boxRepository>/git_source.txt, which is embedded into the compiled
+// binary via //go:embed in box/box_package_git.go. The file is always
+// written (even with an empty string) to satisfy the go:embed directive,
+// which requires the target file to exist at build time. An empty file
+// means "not a git build"; a non-empty file means "git build, this is
+// the spec to pass to uv tool install --from".
+func writeGitSourceFile(boxRepository, gitSource string) error {
+	target := filepath.Join(boxRepository, "git_source.txt")
+	if err := os.WriteFile(target, []byte(gitSource), 0644); err != nil {
+		return fmt.Errorf("failed to write git source file to %s: %w", target, err)
+	}
+	return nil
 }
 
 // validateGitSource is called from preRun when a GitSource CLI argument

--- a/boxer/git.go
+++ b/boxer/git.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// buildGoBuildLdflags constructs the ldflags string passed to `go build`
+// via the `GOFLAGS=-ldflags=...` environment variable. Pure function:
+// no side effects, no package-level state reads, so it can be unit-tested
+// without invoking go build. The arguments mirror the inputs the caller
+// has at the point of invocation (gitSource CLI arg, WheelsToEmbed list).
+//
+// Behavior:
+//   - Always includes "-s -w" to strip debug info.
+//   - If wheels are embedded, adds "-X main.INSTALL_WHEELS=yes" (unchanged
+//     from the pre-git-support behavior — regression test locks this in).
+//   - If a git source is set, adds "-X main.GIT_SOURCE=<spec>".
+//
+// The git and wheel flags are independent: validateGitSource + CLI command
+// separation ensure only one of the two is actually set in practice. This
+// function does not enforce mutual exclusion; the CLI layer does.
+func buildGoBuildLdflags(gitSource string, wheelsToEmbed []string) string {
+	ldflags := "-s -w"
+	if len(wheelsToEmbed) > 0 {
+		ldflags += " -X main.INSTALL_WHEELS=yes"
+	}
+	if gitSource != "" {
+		ldflags += fmt.Sprintf(" -X main.GIT_SOURCE=%s", gitSource)
+	}
+	return ldflags
+}
+
+// validateGitSource is called from preRun when a GitSource CLI argument
+// was provided. It enforces the only format constraint we validate in
+// uvbox: the spec must begin with "git+". Everything else is delegated
+// to uv, which surfaces malformed specs loudly on first run of the
+// generated binary.
+func validateGitSource(gitSource string) error {
+	if gitSource == "" {
+		return fmt.Errorf("git source must not be empty")
+	}
+	if !strings.HasPrefix(gitSource, "git+") {
+		return fmt.Errorf("git source must start with 'git+' (e.g. git+https://github.com/org/repo), got %q", gitSource)
+	}
+	return nil
+}

--- a/boxer/git_test.go
+++ b/boxer/git_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildGoBuildLdflags_Pypi is a regression guard: the ldflag string
+// produced for a plain pypi build must match what goBuild used to produce
+// before git support was added.
+func TestBuildGoBuildLdflags_Pypi(t *testing.T) {
+	got := buildGoBuildLdflags("", nil)
+	want := "-s -w"
+	if got != want {
+		t.Fatalf("buildGoBuildLdflags pypi = %q, want %q", got, want)
+	}
+}
+
+// TestBuildGoBuildLdflags_Wheel is a regression guard for the wheel path.
+func TestBuildGoBuildLdflags_Wheel(t *testing.T) {
+	got := buildGoBuildLdflags("", []string{"some-wheel.whl"})
+	want := "-s -w -X main.INSTALL_WHEELS=yes"
+	if got != want {
+		t.Fatalf("buildGoBuildLdflags wheel = %q, want %q", got, want)
+	}
+}
+
+func TestBuildGoBuildLdflags_Git(t *testing.T) {
+	got := buildGoBuildLdflags("git+https://github.com/org/repo@main", nil)
+	if !strings.Contains(got, "-s -w") {
+		t.Errorf("expected base flags -s -w, got %q", got)
+	}
+	if !strings.Contains(got, "-X main.GIT_SOURCE=git+https://github.com/org/repo@main") {
+		t.Errorf("expected -X main.GIT_SOURCE, got %q", got)
+	}
+	if strings.Contains(got, "INSTALL_WHEELS") {
+		t.Errorf("git build must not set INSTALL_WHEELS, got %q", got)
+	}
+}
+
+// TestBuildGoBuildLdflags_GitDoesNotOmitOnWheels covers the edge case
+// where both inputs are set. CLI validation enforces mutual exclusion at
+// the command layer; this test just verifies the helper itself still emits
+// the git flag if both happen to be passed.
+func TestBuildGoBuildLdflags_GitDoesNotOmitOnWheels(t *testing.T) {
+	got := buildGoBuildLdflags("git+https://github.com/org/repo", []string{"some.whl"})
+	if !strings.Contains(got, "-X main.GIT_SOURCE=git+https://github.com/org/repo") {
+		t.Errorf("expected -X main.GIT_SOURCE in output, got %q", got)
+	}
+}

--- a/boxer/git_test.go
+++ b/boxer/git_test.go
@@ -1,15 +1,17 @@
 package main
 
 import (
-	"strings"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
 // TestBuildGoBuildLdflags_Pypi is a regression guard: the ldflag string
 // produced for a plain pypi build must match what goBuild used to produce
-// before git support was added.
+// before git support was added. Git support does NOT inject ldflags
+// (see boxer/git.go for why) so adding it must not change this output.
 func TestBuildGoBuildLdflags_Pypi(t *testing.T) {
-	got := buildGoBuildLdflags("", nil)
+	got := buildGoBuildLdflags(nil)
 	want := "-s -w"
 	if got != want {
 		t.Fatalf("buildGoBuildLdflags pypi = %q, want %q", got, want)
@@ -18,34 +20,42 @@ func TestBuildGoBuildLdflags_Pypi(t *testing.T) {
 
 // TestBuildGoBuildLdflags_Wheel is a regression guard for the wheel path.
 func TestBuildGoBuildLdflags_Wheel(t *testing.T) {
-	got := buildGoBuildLdflags("", []string{"some-wheel.whl"})
+	got := buildGoBuildLdflags([]string{"some-wheel.whl"})
 	want := "-s -w -X main.INSTALL_WHEELS=yes"
 	if got != want {
 		t.Fatalf("buildGoBuildLdflags wheel = %q, want %q", got, want)
 	}
 }
 
-func TestBuildGoBuildLdflags_Git(t *testing.T) {
-	got := buildGoBuildLdflags("git+https://github.com/org/repo@main", nil)
-	if !strings.Contains(got, "-s -w") {
-		t.Errorf("expected base flags -s -w, got %q", got)
+func TestWriteGitSourceFile_Empty(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeGitSourceFile(dir, ""); err != nil {
+		t.Fatalf("writeGitSourceFile empty failed: %v", err)
 	}
-	if !strings.Contains(got, "-X main.GIT_SOURCE=git+https://github.com/org/repo@main") {
-		t.Errorf("expected -X main.GIT_SOURCE, got %q", got)
+
+	got, err := os.ReadFile(filepath.Join(dir, "git_source.txt"))
+	if err != nil {
+		t.Fatalf("failed to read written file: %v", err)
 	}
-	if strings.Contains(got, "INSTALL_WHEELS") {
-		t.Errorf("git build must not set INSTALL_WHEELS, got %q", got)
+	if string(got) != "" {
+		t.Fatalf("expected empty file, got %q", string(got))
 	}
 }
 
-// TestBuildGoBuildLdflags_GitDoesNotOmitOnWheels covers the edge case
-// where both inputs are set. CLI validation enforces mutual exclusion at
-// the command layer; this test just verifies the helper itself still emits
-// the git flag if both happen to be passed.
-func TestBuildGoBuildLdflags_GitDoesNotOmitOnWheels(t *testing.T) {
-	got := buildGoBuildLdflags("git+https://github.com/org/repo", []string{"some.whl"})
-	if !strings.Contains(got, "-X main.GIT_SOURCE=git+https://github.com/org/repo") {
-		t.Errorf("expected -X main.GIT_SOURCE in output, got %q", got)
+func TestWriteGitSourceFile_WithSpec(t *testing.T) {
+	dir := t.TempDir()
+	spec := "git+https://github.com/org/repo@main"
+
+	if err := writeGitSourceFile(dir, spec); err != nil {
+		t.Fatalf("writeGitSourceFile failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "git_source.txt"))
+	if err != nil {
+		t.Fatalf("failed to read written file: %v", err)
+	}
+	if string(got) != spec {
+		t.Fatalf("expected %q, got %q", spec, string(got))
 	}
 }
 

--- a/boxer/git_test.go
+++ b/boxer/git_test.go
@@ -48,3 +48,44 @@ func TestBuildGoBuildLdflags_GitDoesNotOmitOnWheels(t *testing.T) {
 		t.Errorf("expected -X main.GIT_SOURCE in output, got %q", got)
 	}
 }
+
+func TestValidateGitSource_Empty(t *testing.T) {
+	if err := validateGitSource(""); err == nil {
+		t.Fatal("expected error for empty git source, got nil")
+	}
+}
+
+func TestValidateGitSource_MissingGitPrefix(t *testing.T) {
+	cases := []string{
+		"https://github.com/org/repo",
+		"http://github.com/org/repo",
+		"github.com/org/repo",
+		"ssh://git@github.com/org/repo",
+		"file:///tmp/repo",
+	}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			if err := validateGitSource(s); err == nil {
+				t.Fatalf("expected error for %q, got nil", s)
+			}
+		})
+	}
+}
+
+func TestValidateGitSource_AcceptsValidSpecs(t *testing.T) {
+	cases := []string{
+		"git+https://github.com/org/repo",
+		"git+https://github.com/org/repo@main",
+		"git+https://github.com/org/repo@v1.0.0",
+		"git+https://github.com/org/repo@abc123def456",
+		"git+ssh://git@github.com/org/repo",
+		"git+ssh://git@github.com/org/repo@main",
+	}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			if err := validateGitSource(s); err != nil {
+				t.Fatalf("expected %q to be valid, got error: %v", s, err)
+			}
+		})
+	}
+}

--- a/boxer/main.go
+++ b/boxer/main.go
@@ -249,6 +249,13 @@ func insertFilesIntoBoxRepository(boxRepository string) error {
 		}
 	}
 
+	// Write the git source file (always — empty for pypi/wheel builds,
+	// populated for `uvbox git <spec>` builds). See boxer/git.go and
+	// box/box_package_git.go for the embed mechanism.
+	if err := writeGitSourceFile(boxRepository, GitSource); err != nil {
+		return fmt.Errorf("failed to write git source file: %w", err)
+	}
+
 	return nil
 }
 
@@ -370,7 +377,9 @@ func goBuild(repository, buildName, platform, arch string) error {
 	var outbuf, errbuf strings.Builder
 
 	// Compilation flag — see boxer/git.go for the pure helper and its tests.
-	ldflags := buildGoBuildLdflags(GitSource, WheelsToEmbed)
+	// Git source is NOT injected via ldflags (Go's GOFLAGS parser rejects
+	// `-X main.FOO=bar`); it is embedded via box/git_source.txt instead.
+	ldflags := buildGoBuildLdflags(WheelsToEmbed)
 
 	// Command
 	cmd := exec.Command("go", "build", "-o", buildName)

--- a/boxer/main.go
+++ b/boxer/main.go
@@ -31,6 +31,7 @@ var Config string
 var Output string
 var Nfpm string
 var ReleaseVersion string
+var GitSource string
 
 var Darwin bool
 var Linux bool
@@ -104,6 +105,35 @@ func main() {
 	wheelCmd.Flags().BoolVarP(&Amd, "amd", "", false, "Build for AMD64")
 	wheelCmd.Flags().BoolVarP(&Arm, "arm", "", false, "build for ARM64")
 
+	// UVBOX GIT
+	var gitCmd = &cobra.Command{
+		Use:   "git <git-spec>",
+		Short: "Use a git repository as package source to generate a standalone executable",
+		Long: "Use a git repository as package source to generate a standalone executable.\n\n" +
+			"The git spec is passed through to `uv tool install --from` verbatim.\n" +
+			"Examples:\n" +
+			"  uvbox git git+https://github.com/org/repo\n" +
+			"  uvbox git git+https://github.com/org/repo@main\n" +
+			"  uvbox git git+https://github.com/org/repo@v1.0.0",
+		Args: cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			GitSource = args[0]
+			preRun()
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := run(); err != nil {
+				logger.Fatal("failed to run git command", logger.Args("error", err))
+			}
+		},
+	}
+	gitCmd.Flags().StringVarP(&Config, "config", "c", "", "Configuration file")
+	gitCmd.Flags().StringVarP(&Output, "output", "o", "dist", "Output directory")
+	gitCmd.Flags().BoolVarP(&Darwin, "darwin", "d", false, "Build for darwin")
+	gitCmd.Flags().BoolVarP(&Linux, "linux", "l", false, "Build for linux")
+	gitCmd.Flags().BoolVarP(&Windows, "windows", "w", false, "Build for windows")
+	gitCmd.Flags().BoolVarP(&Amd, "amd", "", false, "Build for AMD64")
+	gitCmd.Flags().BoolVarP(&Arm, "arm", "", false, "build for ARM64")
+
 	// UVBOX
 	var rootCmd = &cobra.Command{
 		Use:   "uvbox",
@@ -112,6 +142,7 @@ func main() {
 	}
 	rootCmd.AddCommand(pypiCmd)
 	rootCmd.AddCommand(wheelCmd)
+	rootCmd.AddCommand(gitCmd)
 	rootCmd.PersistentFlags().StringVarP(&ReleaseVersion, "release-version", "", "0.0.0", "Specify a version for the binaries. Will be used for example for versionning linux packages.")
 	rootCmd.PersistentFlags().BoolVarP(&NoBanner, "no-banner", "", false, "Do not display the banner")
 	rootCmd.PersistentFlags().StringVarP(&Nfpm, "nfpm", "", "", "Generate linux packages with the given nfpm configuration file")
@@ -127,6 +158,7 @@ func preRun() {
 	validateGoAvailability()
 	validateNfpmAvailability()
 	validateWheelsToEmbed()
+	validateGitSourceFlag()
 }
 
 func validateOutputDirectoryFlag() {
@@ -158,6 +190,15 @@ func validateWheelsToEmbed() {
 		} else if !ok {
 			logger.Fatal("wheel should be an existing file", logger.Args("path", wheel))
 		}
+	}
+}
+
+func validateGitSourceFlag() {
+	if GitSource == "" {
+		return
+	}
+	if err := validateGitSource(GitSource); err != nil {
+		logger.Fatal("invalid git source", logger.Args("error", err))
 	}
 }
 
@@ -328,11 +369,8 @@ func goGenerate(repository, platform, arch string) error {
 func goBuild(repository, buildName, platform, arch string) error {
 	var outbuf, errbuf strings.Builder
 
-	// Compilation flag
-	ldflags := "-s -w"
-	if len(WheelsToEmbed) > 0 {
-		ldflags += " -X main.INSTALL_WHEELS=yes"
-	}
+	// Compilation flag — see boxer/git.go for the pure helper and its tests.
+	ldflags := buildGoBuildLdflags(GitSource, WheelsToEmbed)
 
 	// Command
 	cmd := exec.Command("go", "build", "-o", buildName)

--- a/examples/git/simple-app.toml
+++ b/examples/git/simple-app.toml
@@ -1,0 +1,20 @@
+# Build a uvbox binary from a git repository.
+#
+# Usage:
+#   uvbox git git+https://github.com/<org>/<repo> --config examples/git/simple-app.toml
+#
+# The git spec is passed through to `uv tool install --from` at runtime, so
+# any form uv accepts works: @main, @v1.0.0, @<commit-sha>, ssh:// URLs, etc.
+#
+# [package].name must match the distribution name the package registers
+# (what `uv tool list` reports after installation).
+# [package].script must match an entry from the package's [project.scripts].
+
+[package]
+name = "my-app"
+script = "my-app"
+
+# To re-resolve the git ref on every run (equivalent to pycrucible's
+# delete_after_run=true), uncomment:
+# [package.version]
+# auto-update = true


### PR DESCRIPTION
Closes #19.

## Summary

Adds a new `uvbox git <git-spec>` subcommand alongside the existing `pypi` and `wheel` source types. The git spec is passed through to `uv tool install --from` verbatim, so any form `uv` accepts works (`@main`, `@v1.0.0`, `@<commit>`, `ssh://`, etc.).

```bash
uvbox git git+https://github.com/org/repo
uvbox git git+https://github.com/org/repo@v1.0.0
uvbox git git+ssh://git@github.com/org/private-repo
```

Implements the approach @Coruscant11 chose in [this comment](https://github.com/AmadeusITGroup/uvbox/issues/19#issuecomment-4222876492): subcommand with the git spec as a positional CLI argument, no changes to the `uvbox.toml` schema.

The runtime install path runs `uv tool install --from <spec> <name> --upgrade` on every install/update — no version-discovery infrastructure, no tag scanning. `auto-update = true` re-installs on every run, delivering the `pycrucible delete_after_run`-equivalent behavior the issue requested.

## Design notes

- **Additive only.** The pypi and wheel code paths are untouched. A regression test in `box/config_identifier_test.go` locks in a byte-stable golden hash for `ComputeIdentifier` to guarantee existing binaries find the same XDG dir.
- **Distinct identifier per git source.** The git spec participates in `ComputeIdentifier` (only when set), so binaries built from `git+url@main` and `git+url@v1.0.0` get separate isolated install dirs. No cross-contamination with pypi-built binaries of the same package.
- **Source embedding via file, not ldflag.** See \"Pre-existing bug discovered\" below.
- **Validation is minimal:** the spec must be non-empty and start with `git+`. Everything else is delegated to `uv`, which surfaces malformed specs loudly on first run.

## Pre-existing bug discovered (and worked around)

The original spec proposed embedding the git source via `-ldflags \"-X main.GIT_SOURCE=...\"`. The smoke test surfaced that this **does not work** because of a pre-existing bug introduced in #14 (commit f19680f, \"fix: Use environment variables for ldflags\"):

> Go's \`GOFLAGS\` parser uses \`strings.Fields\` (whitespace split, no quote handling). Any ldflag string containing \`-X main.foo=bar\` is split across whitespace, and Go rejects \`-X\` as an unknown top-level flag with \`go: parsing \$GOFLAGS: unknown flag -X\`.

This silently broke the **`uvbox wheel` path** in main since #14 was merged — it sets `-X main.INSTALL_WHEELS=yes`, which fails the same way. No test exercises wheel mode end-to-end so nobody noticed. Reproduction:

```bash
GOFLAGS='-ldflags=-s -w -X main.INSTALL_WHEELS=yes' go build -o hello .
# go: parsing $GOFLAGS: unknown flag -X
```

**This PR does not fix the wheel bug** — touching it requires re-validating the original Windows-via-uvx fix from #14 on Windows, which is out of scope here. The wheel path remains broken in main and should be addressed in a separate PR.

For git, this PR sidesteps GOFLAGS entirely by embedding the source in a small file (`box/git_source.txt`) read at compile time via `//go:embed`. boxer's `writeGitSourceFile` writes the spec into this file before `go build`. Empty file = pypi/wheel build, non-empty = git build. Same end result, different transport.

## Files

**Runtime (\`box/\`):**
- `box/box_package_git.go` (new) — `GIT_SOURCE` (loaded from embedded `git_source.txt`), `uvToolInstallGit`, `buildUvToolInstallFromArgs` pure helper
- `box/box_package.go` — one new branch in `uvToolInstall` dispatching to git when `GIT_SOURCE != \"\"` (existing pypi/wheel logic untouched)
- `box/config.go` — `ComputeIdentifier` conditionally appends `GIT_SOURCE` (no-op when empty)
- `box/generate.go` — adds empty `git_source.txt` placeholder generation, mirroring the existing `wheels/placeholder` pattern
- `box/config_identifier_test.go` (new) — golden-hash regression test + git distinction tests
- `box/box_package_git_test.go` (new) — pure-helper command-shape tests

**Build-time (\`boxer/\`):**
- `boxer/git.go` (new) — `buildGoBuildLdflags` pure helper (now without git, since git uses file embed), `validateGitSource`, `writeGitSourceFile`
- `boxer/main.go` — new `gitCmd` cobra command, `GitSource` CLI var, `validateGitSourceFlag` in preRun, `writeGitSourceFile` call in `insertFilesIntoBoxRepository`
- `boxer/git_test.go` (new) — ldflag regression tests for pypi/wheel, `writeGitSourceFile` tests, `validateGitSource` tests

**Docs:**
- `README.md` — feature bullet updated, new \"Build from a Git Repository\" section, behavior of `[package.version]` for git builds, private repo auth note
- `examples/git/simple-app.toml` (new) — minimal example
- `.gitignore` — adds `box/git_source.txt`

## Test Plan

- [x] Full `box` test suite passes (`go test ./...`) including the `ComputeIdentifier` golden-hash regression guard
- [x] Full `boxer` test suite passes including ldflag regression guards for the existing pypi/wheel paths
- [x] Manual smoke test: `uvbox git git+https://github.com/VaasuDevanS/cowsay-python --darwin --arm` builds, the resulting binary runs end-to-end (`./cowsay -t \"hi\"` prints the cow), `self update` reports \"Already up-to-date\", `self path` shows a git-distinct identifier
- [x] Regression: `uvbox pypi` still works, produces a different identifier hash (separate XDG dir from the git build of the same package)

Reviewers can reproduce the smoke test:
```bash
cd boxer && go generate && go build -o /tmp/uvbox . && cd ..
mkdir /tmp/smoke && cd /tmp/smoke
cat > uvbox.toml <<TOML
[package]
name = \"cowsay\"
script = \"cowsay\"
TOML
/tmp/uvbox git git+https://github.com/VaasuDevanS/cowsay-python --darwin --arm  # adjust to host
cd dist && tar xzf cowsay-*.tar.gz && ./cowsay -t \"git works!\"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)