### PR TITLE
feat: add 'uvbox git' subcommand for git repository sources (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 box/uvbox.toml
 box/wheels
+box/git_source.txt
 
 boxer/boxes
 boxer/boxer

--- a/README.md
+++ b/README.md
@@ -153,16 +153,17 @@ build machine; the end user's local git/ssh setup handles authentication.
 
 **Behavior of `[package.version]` for git builds:**
 - `static` and `dynamic` are ignored for install resolution — the git ref in
-  the spec is the source of truth. `uvToolInstallGit` never consults them.
-- With `auto-update = true` and no `[package.version]` set, uvbox re-runs
-  `uv tool install --from <spec> --upgrade` on every invocation, giving you
-  the "fresh dependencies every run" behavior equivalent to `pycrucible`'s
-  `delete_after_run = true`. This works because the internal version
-  comparison treats the unset case as always-stale.
-- Setting `static = "x.y.z"` or a `dynamic` URL that resolves to the
-  currently installed version will **disable** the always-update behavior:
-  the version compare matches, and the update path is skipped. Leave both
-  unset when tracking a moving branch.
+  the spec is the source of truth. `uvToolInstallGit` logs a warning and
+  drops any supplied version. Leave both unset when tracking a moving branch.
+- With `auto-update = true` and neither `static` nor `dynamic` set, the
+  runtime version check has no target to compare against and falls through
+  to re-running `uv tool install --from <spec> --upgrade` on every
+  invocation, giving you the "fresh dependencies every run" behavior
+  equivalent to `pycrucible`'s `delete_after_run = true`.
+- Setting `static = "x.y.z"` or a `dynamic` URL that happens to resolve to
+  the currently installed version will **disable** the always-update
+  behavior — the outer version compare matches and skips the update path
+  before `uvToolInstallGit` ever runs.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,9 @@ See the [`examples/`](./examples) directory for complete working examples:
 ### Runtime (Generated Binaries)
 
 - **libc** (standard C library, required by Python itself)
+- **git** (only for binaries built with `uvbox git` — `uv` shells out to the
+  system `git` on first run to clone the repository. For `ssh://` specs, the
+  end user's local SSH keys/agent are used for authentication.)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ pip install uvbox
 
 ### Basic Usage
 
+uvbox supports three source types, each via its own subcommand:
+
+- **`uvbox pypi`** — install the package from a package index (PyPI by default)
+- **`uvbox wheel`** — bundle one or more local wheel files into the binary
+- **`uvbox git`** — fetch the package from a git repository at runtime
+
 Create a simple configuration and build:
 
 ```bash
@@ -118,20 +124,22 @@ uvbox wheel --config uvbox.toml ./my-app.whl
 
 ### Build from a Git Repository
 
-Package an application from a git repository that isn't published to PyPI:
+Package an application from a git repository that isn't published to PyPI.
+The examples below use [`VaasuDevanS/cowsay-python`](https://github.com/VaasuDevanS/cowsay-python)
+so they're copy-paste runnable — pair them with [`examples/git/simple-app.toml`](./examples/git/simple-app.toml):
 
 ```bash
 # Default branch
-uvbox git git+https://github.com/org/repo --config uvbox.toml
+uvbox git git+https://github.com/VaasuDevanS/cowsay-python --config examples/git/simple-app.toml
 
 # Specific tag
-uvbox git git+https://github.com/org/repo@v1.0.0
+uvbox git git+https://github.com/VaasuDevanS/cowsay-python@v6.1
 
 # Specific branch
-uvbox git git+https://github.com/org/repo@main
+uvbox git git+https://github.com/VaasuDevanS/cowsay-python@main
 
 # Specific commit
-uvbox git git+https://github.com/org/repo@abc123
+uvbox git git+https://github.com/VaasuDevanS/cowsay-python@abc123
 
 # SSH (uses your local git credentials)
 uvbox git git+ssh://git@github.com/org/private-repo
@@ -145,12 +153,16 @@ build machine; the end user's local git/ssh setup handles authentication.
 
 **Behavior of `[package.version]` for git builds:**
 - `static` and `dynamic` are ignored for install resolution — the git ref in
-  the spec is the source of truth.
-- `auto-update = true` re-runs `uv tool install --from <spec> --upgrade` on
-  every invocation, giving you the "fresh dependencies every run" behavior
-  equivalent to `pycrucible`'s `delete_after_run = true`.
-- Leave `dynamic` unset when tracking a moving branch; setting it will disable
-  the always-update behavior.
+  the spec is the source of truth. `uvToolInstallGit` never consults them.
+- With `auto-update = true` and no `[package.version]` set, uvbox re-runs
+  `uv tool install --from <spec> --upgrade` on every invocation, giving you
+  the "fresh dependencies every run" behavior equivalent to `pycrucible`'s
+  `delete_after_run = true`. This works because the internal version
+  comparison treats the unset case as always-stale.
+- Setting `static = "x.y.z"` or a `dynamic` URL that resolves to the
+  currently installed version will **disable** the always-update behavior:
+  the version compare matches, and the update path is skipped. Leave both
+  unset when tracking a moving branch.
 
 ## Configuration
 
@@ -236,8 +248,12 @@ environment = [
 #### `[package]`
 Core package configuration.
 
-- **`name`** (required) — Package name to install from PyPI
-- **`script`** (required) — Entry point script to run (from `[project.scripts]` in your package)
+- **`name`** (required) — Distribution name the package registers (what
+  `uv tool list` reports after install). Used for all source types
+  (`pypi`, `wheel`, `git`) — for `git` it must match the name declared in
+  the repo's `pyproject.toml`, not the repo/org slug.
+- **`script`** (required) — Entry point to run. Must match an entry from
+  the package's `[project.scripts]`. Applies to all source types.
 
 #### `[package.version]`
 Version management and updates.
@@ -408,11 +424,11 @@ auto-update = true
 
 See the [`examples/`](./examples) directory for complete working examples:
 
-- [`simple-app.toml`](./examples/git/simple-app.toml) — Minimal Python Package from Git repository
-- [`simple-app.toml`](./examples/pypi/simple-app.toml) — Minimal Python Package from PyPI
-- [`custom-registry.toml`](./examples/pypi/custom-registry.toml) — Custom registry and mirrors
-- [`custom-certs.toml`](./examples/pypi/custom-certs.toml) — Corporate CA bundle
-- [`optional-dependency.toml`](./examples/pypi/optional-dependency.toml) - Install a package with an optional dependency
+- [`git/simple-app.toml`](./examples/git/simple-app.toml) — Minimal Python package from a Git repository
+- [`pypi/simple-app.toml`](./examples/pypi/simple-app.toml) — Minimal Python package from PyPI
+- [`pypi/custom-registry.toml`](./examples/pypi/custom-registry.toml) — Custom registry and mirrors
+- [`pypi/custom-certs.toml`](./examples/pypi/custom-certs.toml) — Corporate CA bundle
+- [`pypi/optional-dependency.toml`](./examples/pypi/optional-dependency.toml) — Install a package with an optional dependency
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,8 @@ auto-update = true
 
 See the [`examples/`](./examples) directory for complete working examples:
 
-- [`simple-app.toml`](./examples/pypi/simple-app.toml) — Minimal PyPI package
+- [`simple-app.toml`](./examples/git/simple-app.toml) — Minimal Python Package from Git repository
+- [`simple-app.toml`](./examples/pypi/simple-app.toml) — Minimal Python Package from PyPI
 - [`custom-registry.toml`](./examples/pypi/custom-registry.toml) — Custom registry and mirrors
 - [`custom-certs.toml`](./examples/pypi/custom-certs.toml) — Corporate CA bundle
 - [`optional-dependency.toml`](./examples/pypi/optional-dependency.toml) - Install a package with an optional dependency

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ## Features
 
-- **Package from PyPI or Wheels** — Install your application from package indexes or choose to bundle local wheel files
+- **Package from PyPI, Wheels, or Git** — Install your application from package indexes, bundle local wheel files, or fetch from a git repository
 - **True Cross-Compilation** — Build binaries for Linux, macOS, and Windows (AMD64/ARM64) from any platform in seconds
 - **Auto-Updates** — Built-in version checking and self-update/fallback capabilities for your binaries
 - **Dependency Freezing** — Use constraints files to ensure reproducible installations
@@ -115,6 +115,42 @@ Package local wheel files instead of installing from PyPI:
 ```bash
 uvbox wheel --config uvbox.toml ./my-app.whl
 ```
+
+### Build from a Git Repository
+
+Package an application from a git repository that isn't published to PyPI:
+
+```bash
+# Default branch
+uvbox git git+https://github.com/org/repo --config uvbox.toml
+
+# Specific tag
+uvbox git git+https://github.com/org/repo@v1.0.0
+
+# Specific branch
+uvbox git git+https://github.com/org/repo@main
+
+# Specific commit
+uvbox git git+https://github.com/org/repo@abc123
+
+# SSH (uses your local git credentials)
+uvbox git git+ssh://git@github.com/org/private-repo
+```
+
+The git spec is passed through to `uv tool install --from` verbatim at runtime
+on the end-user's machine. `uvbox` itself never clones the repository at build
+time — the clone happens on first run of the generated binary. This means you
+can build binaries for a private repo without providing credentials to the
+build machine; the end user's local git/ssh setup handles authentication.
+
+**Behavior of `[package.version]` for git builds:**
+- `static` and `dynamic` are ignored for install resolution — the git ref in
+  the spec is the source of truth.
+- `auto-update = true` re-runs `uv tool install --from <spec> --upgrade` on
+  every invocation, giving you the "fresh dependencies every run" behavior
+  equivalent to `pycrucible`'s `delete_after_run = true`.
+- Leave `dynamic` unset when tracking a moving branch; setting it will disable
+  the always-update behavior.
 
 ## Configuration
 

--- a/box/box_package.go
+++ b/box/box_package.go
@@ -92,7 +92,7 @@ func (b *Box) InstallPackage(packageVersion, packageConstraintsUrl string) error
 	if packageConstraintsUrl != "" {
 		file, err := downloadTemporaryFile(packageConstraintsUrl)
 		if err != nil {
-			return fmt.Errorf("failed to download constraints file from %s: %w", packageConstraintsUrl, err)
+			logger.Debug("Failed to download constraints file", logger.Args("error", err))
 		}
 		constraintsFile = file
 	}
@@ -246,6 +246,7 @@ func (b *Box) uvToolInstallPypi(packageVersion, constraintsFile string) error {
 		"name":            b.PackageName,
 		"version":         packageVersion,
 		"constraintsFile": constraintsFile,
+		"method":          "pypi",
 	}
 	logger.Debug("Installing package", logger.ArgsFromMap(debugArgsMap))
 

--- a/box/box_package.go
+++ b/box/box_package.go
@@ -157,6 +157,9 @@ func (b *Box) InstalledPackagePath() (string, error) {
 }
 
 func (b *Box) uvToolInstall(packageVersion, constraintsFile string) error {
+	if GIT_SOURCE != "" {
+		return b.uvToolInstallGit(constraintsFile)
+	}
 	if INSTALL_WHEELS == "no" {
 		return b.uvToolInstallPypi(packageVersion, constraintsFile)
 	} else {

--- a/box/box_package.go
+++ b/box/box_package.go
@@ -92,7 +92,7 @@ func (b *Box) InstallPackage(packageVersion, packageConstraintsUrl string) error
 	if packageConstraintsUrl != "" {
 		file, err := downloadTemporaryFile(packageConstraintsUrl)
 		if err != nil {
-			logger.Debug("Failed to download constraints file", logger.Args("error", err))
+			return fmt.Errorf("failed to download constraints file from %s: %w", packageConstraintsUrl, err)
 		}
 		constraintsFile = file
 	}
@@ -156,14 +156,47 @@ func (b *Box) InstalledPackagePath() (string, error) {
 	return installedPackage.Path, nil
 }
 
-func (b *Box) uvToolInstall(packageVersion, constraintsFile string) error {
-	if GIT_SOURCE != "" {
-		return b.uvToolInstallGit(constraintsFile)
+// installMethod identifies which install backend uvToolInstall should use.
+type installMethod int
+
+const (
+	installMethodPypi installMethod = iota
+	installMethodWheels
+	installMethodGit
+)
+
+// selectInstallMethod is the pure-function core of the uvToolInstall dispatch.
+// It returns an error when the build-time configuration is inconsistent —
+// specifically when both GIT_SOURCE and INSTALL_WHEELS are set, which would
+// otherwise silently favor one source and discard the other.
+func selectInstallMethod(gitSource, installWheels string) (installMethod, error) {
+	gitSet := gitSource != ""
+	wheelsSet := installWheels == "yes"
+	if gitSet && wheelsSet {
+		return 0, fmt.Errorf("invalid binary: both GIT_SOURCE and INSTALL_WHEELS are set; this indicates a build-time bug, please rebuild")
 	}
-	if INSTALL_WHEELS == "no" {
-		return b.uvToolInstallPypi(packageVersion, constraintsFile)
-	} else {
+	switch {
+	case gitSet:
+		return installMethodGit, nil
+	case wheelsSet:
+		return installMethodWheels, nil
+	default:
+		return installMethodPypi, nil
+	}
+}
+
+func (b *Box) uvToolInstall(packageVersion, constraintsFile string) error {
+	method, err := selectInstallMethod(GIT_SOURCE, INSTALL_WHEELS)
+	if err != nil {
+		return err
+	}
+	switch method {
+	case installMethodGit:
+		return b.uvToolInstallGit(packageVersion, constraintsFile)
+	case installMethodWheels:
 		return b.uvToolInstallWheels(constraintsFile)
+	default:
+		return b.uvToolInstallPypi(packageVersion, constraintsFile)
 	}
 }
 

--- a/box/box_package_git.go
+++ b/box/box_package_git.go
@@ -1,0 +1,7 @@
+package main
+
+// GIT_SOURCE is populated via ldflags at build time (-X main.GIT_SOURCE=git+...)
+// when the binary is produced by `uvbox git <spec>`. When empty, the binary was
+// produced by `uvbox pypi` or `uvbox wheel` and the runtime install path skips
+// the git dispatch entirely.
+var GIT_SOURCE = ""

--- a/box/box_package_git.go
+++ b/box/box_package_git.go
@@ -5,3 +5,27 @@ package main
 // produced by `uvbox pypi` or `uvbox wheel` and the runtime install path skips
 // the git dispatch entirely.
 var GIT_SOURCE = ""
+
+// buildUvToolInstallFromArgs constructs the command-line arguments for
+// `uv tool install --from <gitSource> <packageName> --upgrade`, optionally
+// appending `--with-requirements <constraintsFile>`. Pure function: no
+// side effects, easy to unit-test.
+//
+// The `--upgrade` flag is always included for git sources because there is
+// no "pinned version" concept — every install/update must re-resolve the ref.
+func buildUvToolInstallFromArgs(uvPath, gitSource, packageName, constraintsFile string) []string {
+	args := []string{
+		uvPath,
+		"--quiet",
+		"tool",
+		"install",
+		"--from",
+		gitSource,
+		packageName,
+		"--upgrade",
+	}
+	if constraintsFile != "" {
+		args = append(args, "--with-requirements", constraintsFile)
+	}
+	return args
+}

--- a/box/box_package_git.go
+++ b/box/box_package_git.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"bytes"
 	_ "embed"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -78,8 +76,8 @@ func (b *Box) uvToolInstallGit(packageVersion, constraintsFile string) error {
 			logger.Args("ignoredVersion", packageVersion, "gitSource", GIT_SOURCE))
 	}
 
-	logger.Debug("Installing package from git",
-		logger.Args("name", b.PackageName, "source", GIT_SOURCE, "constraintsFile", constraintsFile))
+	logger.Debug("Installing package",
+		logger.Args("name", b.PackageName, "source", GIT_SOURCE, "constraintsFile", constraintsFile, "method", "git"))
 
 	uv, err := b.InstalledUvExecutablePath()
 	if err != nil {
@@ -93,24 +91,18 @@ func (b *Box) uvToolInstallGit(packageVersion, constraintsFile string) error {
 		return fmt.Errorf("could not get uv environment variables: %w", err)
 	}
 
-	// Capture stdout unconditionally into a buffer so that, on failure,
-	// uv's resolver/auth output is included in the returned error rather
-	// than silently discarded. In verbose modes we also stream it to the
-	// user's terminal live.
-	var stdout bytes.Buffer
 	cmd := exec.Command(commandArgs[0], commandArgs[1:]...)
 	cmd.Env = env
 	cmd.Stderr = os.Stderr
+	// Enable Stdout if debug is enabled
 	if debugEnabled() || traceEnabled() {
-		cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
-	} else {
-		cmd.Stdout = &stdout
+		cmd.Stdout = os.Stdout
 	}
 	logger.Trace("Running", logger.Args("command", commandArgs, "env", env))
 
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("uv failed to install %q from git source %q: %w\nuv output:\n%s",
-			b.PackageName, GIT_SOURCE, err, stdout.String())
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to run command %v: %w", commandArgs, err)
 	}
 
 	logger.Debug("Installed", logger.Args("package", b.PackageName))

--- a/box/box_package_git.go
+++ b/box/box_package_git.go
@@ -1,16 +1,32 @@
 package main
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
-// GIT_SOURCE is populated via ldflags at build time (-X main.GIT_SOURCE=git+...)
-// when the binary is produced by `uvbox git <spec>`. When empty, the binary was
-// produced by `uvbox pypi` or `uvbox wheel` and the runtime install path skips
-// the git dispatch entirely.
-var GIT_SOURCE = ""
+// gitSourceContent is the raw content of git_source.txt, embedded at build
+// time. For `uvbox git <spec>` builds, boxer writes the git spec into this
+// file before invoking `go build`. For pypi/wheel builds, the file exists
+// but is empty — matching the committed placeholder in box/git_source.txt.
+//
+// We use a file-embed instead of an ldflag (-X main.GIT_SOURCE=...) because
+// Go's GOFLAGS parser does not support spaces inside flag values, and the
+// boxer build path routes ldflags through GOFLAGS for Windows compatibility
+// (see issue #7). Passing `-X main.FOO=bar` via GOFLAGS fails to parse.
+//
+//go:embed git_source.txt
+var gitSourceContent string
+
+// GIT_SOURCE is the embedded git source string (e.g., "git+https://github.com/org/repo@main")
+// for binaries produced by `uvbox git <spec>`. It is empty for pypi/wheel
+// builds, in which case the runtime install path skips the git dispatch
+// entirely. Trimmed on init to tolerate trailing whitespace/newlines in
+// the embedded file.
+var GIT_SOURCE = strings.TrimSpace(gitSourceContent)
 
 // buildUvToolInstallFromArgs constructs the command-line arguments for
 // `uv tool install --from <gitSource> <packageName> --upgrade`, optionally

--- a/box/box_package_git.go
+++ b/box/box_package_git.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	_ "embed"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -10,13 +12,16 @@ import (
 
 // gitSourceContent is the raw content of git_source.txt, embedded at build
 // time. For `uvbox git <spec>` builds, boxer writes the git spec into this
-// file before invoking `go build`. For pypi/wheel builds, the file exists
-// but is empty — matching the committed placeholder in box/git_source.txt.
+// file before invoking `go build`. For pypi/wheel builds, the file is
+// created empty by box/generate.go (it is gitignored — not a committed
+// file) so the //go:embed directive always has a target.
 //
 // We use a file-embed instead of an ldflag (-X main.GIT_SOURCE=...) because
-// Go's GOFLAGS parser does not support spaces inside flag values, and the
-// boxer build path routes ldflags through GOFLAGS for Windows compatibility
-// (see issue #7). Passing `-X main.FOO=bar` via GOFLAGS fails to parse.
+// the Go toolchain splits GOFLAGS on whitespace, so any ldflag value
+// containing spaces (or `-X main.FOO=bar` that uses an `=` plus another
+// flag) breaks parsing. The boxer build path routes ldflags through GOFLAGS
+// for Windows compatibility (see issue AmadeusITGroup/uvbox#7 and the
+// comment above buildGoBuildLdflags in boxer/git.go).
 //
 //go:embed git_source.txt
 var gitSourceContent string
@@ -24,17 +29,24 @@ var gitSourceContent string
 // GIT_SOURCE is the embedded git source string (e.g., "git+https://github.com/org/repo@main")
 // for binaries produced by `uvbox git <spec>`. It is empty for pypi/wheel
 // builds, in which case the runtime install path skips the git dispatch
-// entirely. Trimmed on init to tolerate trailing whitespace/newlines in
-// the embedded file.
+// entirely. strings.TrimSpace tolerates a trailing newline if the writer
+// ever grows one.
 var GIT_SOURCE = strings.TrimSpace(gitSourceContent)
 
 // buildUvToolInstallFromArgs constructs the command-line arguments for
 // `uv tool install --from <gitSource> <packageName> --upgrade`, optionally
-// appending `--with-requirements <constraintsFile>`. Pure function: no
-// side effects, easy to unit-test.
+// appending `--with-requirements <constraintsFile>`. Pulled out as a
+// standalone helper so it can be tested without invoking `uv`.
 //
-// The `--upgrade` flag is always included for git sources because there is
-// no "pinned version" concept — every install/update must re-resolve the ref.
+// `--upgrade` is always included because uv has no cached version identity
+// for a git install — the ref in the spec is opaque to uv's upgrade check,
+// so forcing the re-install path is the only way to pick up new commits
+// for a moving ref like `@main`. Whether this function is *called* at all
+// is still gated by the outer version-check path in box/main.go — see the
+// README section "Behavior of [package.version] for git builds".
+//
+// Constraints apply to the transitive dependency resolution — the primary
+// package is pinned by the git ref itself.
 func buildUvToolInstallFromArgs(uvPath, gitSource, packageName, constraintsFile string) []string {
 	args := []string{
 		uvPath,
@@ -53,10 +65,19 @@ func buildUvToolInstallFromArgs(uvPath, gitSource, packageName, constraintsFile 
 }
 
 // uvToolInstallGit installs the package from the embedded GIT_SOURCE via
-// `uv tool install --from <GIT_SOURCE> <PackageName> --upgrade`. Mirrors
-// uvToolInstallPypi and uvToolInstallWheels in shape and error handling,
-// but uses --from to delegate git-spec parsing to uv itself.
-func (b *Box) uvToolInstallGit(constraintsFile string) error {
+// `uv tool install --from <GIT_SOURCE> <PackageName> --upgrade`.
+//
+// packageVersion is accepted for signature parity with uvToolInstallPypi,
+// but is intentionally not used to construct the install spec: the git ref
+// in GIT_SOURCE is the source of truth. If the caller supplies a non-empty
+// packageVersion (i.e., the user set [package.version].static on a git
+// build), a user-visible warning is emitted so the mismatch is not silent.
+func (b *Box) uvToolInstallGit(packageVersion, constraintsFile string) error {
+	if packageVersion != "" {
+		logger.Warn("Ignoring [package.version] for git source; the git ref in GIT_SOURCE is the source of truth",
+			logger.Args("ignoredVersion", packageVersion, "gitSource", GIT_SOURCE))
+	}
+
 	logger.Debug("Installing package from git",
 		logger.Args("name", b.PackageName, "source", GIT_SOURCE, "constraintsFile", constraintsFile))
 
@@ -72,16 +93,24 @@ func (b *Box) uvToolInstallGit(constraintsFile string) error {
 		return fmt.Errorf("could not get uv environment variables: %w", err)
 	}
 
+	// Capture stdout unconditionally into a buffer so that, on failure,
+	// uv's resolver/auth output is included in the returned error rather
+	// than silently discarded. In verbose modes we also stream it to the
+	// user's terminal live.
+	var stdout bytes.Buffer
 	cmd := exec.Command(commandArgs[0], commandArgs[1:]...)
 	cmd.Env = env
 	cmd.Stderr = os.Stderr
 	if debugEnabled() || traceEnabled() {
-		cmd.Stdout = os.Stdout
+		cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+	} else {
+		cmd.Stdout = &stdout
 	}
 	logger.Trace("Running", logger.Args("command", commandArgs, "env", env))
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to run command %v: %w", commandArgs, err)
+		return fmt.Errorf("uv failed to install %q from git source %q: %w\nuv output:\n%s",
+			b.PackageName, GIT_SOURCE, err, stdout.String())
 	}
 
 	logger.Debug("Installed", logger.Args("package", b.PackageName))

--- a/box/box_package_git.go
+++ b/box/box_package_git.go
@@ -1,5 +1,11 @@
 package main
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
 // GIT_SOURCE is populated via ldflags at build time (-X main.GIT_SOURCE=git+...)
 // when the binary is produced by `uvbox git <spec>`. When empty, the binary was
 // produced by `uvbox pypi` or `uvbox wheel` and the runtime install path skips
@@ -28,4 +34,40 @@ func buildUvToolInstallFromArgs(uvPath, gitSource, packageName, constraintsFile 
 		args = append(args, "--with-requirements", constraintsFile)
 	}
 	return args
+}
+
+// uvToolInstallGit installs the package from the embedded GIT_SOURCE via
+// `uv tool install --from <GIT_SOURCE> <PackageName> --upgrade`. Mirrors
+// uvToolInstallPypi and uvToolInstallWheels in shape and error handling,
+// but uses --from to delegate git-spec parsing to uv itself.
+func (b *Box) uvToolInstallGit(constraintsFile string) error {
+	logger.Debug("Installing package from git",
+		logger.Args("name", b.PackageName, "source", GIT_SOURCE, "constraintsFile", constraintsFile))
+
+	uv, err := b.InstalledUvExecutablePath()
+	if err != nil {
+		return fmt.Errorf("could not find uv executable: %w", err)
+	}
+
+	commandArgs := buildUvToolInstallFromArgs(uv, GIT_SOURCE, b.PackageName, constraintsFile)
+
+	env, err := b.commandsEnvironment()
+	if err != nil {
+		return fmt.Errorf("could not get uv environment variables: %w", err)
+	}
+
+	cmd := exec.Command(commandArgs[0], commandArgs[1:]...)
+	cmd.Env = env
+	cmd.Stderr = os.Stderr
+	if debugEnabled() || traceEnabled() {
+		cmd.Stdout = os.Stdout
+	}
+	logger.Trace("Running", logger.Args("command", commandArgs, "env", env))
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run command %v: %w", commandArgs, err)
+	}
+
+	logger.Debug("Installed", logger.Args("package", b.PackageName))
+	return nil
 }

--- a/box/box_package_git_test.go
+++ b/box/box_package_git_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildUvToolInstallFromArgs_Minimal(t *testing.T) {
+	got := buildUvToolInstallFromArgs("/path/to/uv", "git+https://github.com/org/repo", "mypkg", "")
+	want := []string{
+		"/path/to/uv",
+		"--quiet",
+		"tool",
+		"install",
+		"--from",
+		"git+https://github.com/org/repo",
+		"mypkg",
+		"--upgrade",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildUvToolInstallFromArgs minimal = %v, want %v", got, want)
+	}
+}
+
+func TestBuildUvToolInstallFromArgs_WithRef(t *testing.T) {
+	got := buildUvToolInstallFromArgs("uv", "git+https://github.com/org/repo@v1.0.0", "mypkg", "")
+	want := []string{
+		"uv",
+		"--quiet",
+		"tool",
+		"install",
+		"--from",
+		"git+https://github.com/org/repo@v1.0.0",
+		"mypkg",
+		"--upgrade",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildUvToolInstallFromArgs with ref = %v, want %v", got, want)
+	}
+}
+
+func TestBuildUvToolInstallFromArgs_WithConstraints(t *testing.T) {
+	got := buildUvToolInstallFromArgs("uv", "git+https://github.com/org/repo", "mypkg", "/tmp/constraints.txt")
+	want := []string{
+		"uv",
+		"--quiet",
+		"tool",
+		"install",
+		"--from",
+		"git+https://github.com/org/repo",
+		"mypkg",
+		"--upgrade",
+		"--with-requirements",
+		"/tmp/constraints.txt",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildUvToolInstallFromArgs with constraints = %v, want %v", got, want)
+	}
+}

--- a/box/box_package_test.go
+++ b/box/box_package_test.go
@@ -1,0 +1,38 @@
+package main
+
+import "testing"
+
+func TestSelectInstallMethod(t *testing.T) {
+	cases := []struct {
+		name          string
+		gitSource     string
+		installWheels string
+		want          installMethod
+		wantErr       bool
+	}{
+		{"pypi_default", "", "no", installMethodPypi, false},
+		{"pypi_empty_install_wheels", "", "", installMethodPypi, false},
+		{"wheels", "", "yes", installMethodWheels, false},
+		{"git_no_wheels", "git+https://github.com/org/repo", "no", installMethodGit, false},
+		{"git_empty_install_wheels", "git+https://github.com/org/repo@main", "", installMethodGit, false},
+		{"conflict_git_and_wheels", "git+https://github.com/org/repo", "yes", 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := selectInstallMethod(tc.gitSource, tc.installWheels)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for git+wheels conflict, got method=%v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("selectInstallMethod(%q, %q) = %v, want %v", tc.gitSource, tc.installWheels, got, tc.want)
+			}
+		})
+	}
+}

--- a/box/config.go
+++ b/box/config.go
@@ -70,6 +70,9 @@ func (c Configuration) PanicIfInvalid() {
 func (c Configuration) ComputeIdentifier() string {
 	hasher := crypto.SHA1.New()
 	textToHash := fmt.Sprintf("%s%s%s%t", c.Package.Name, c.Package.Script, c.Package.Version.Static, c.AutoUpdateEnabled())
+	if GIT_SOURCE != "" {
+		textToHash += GIT_SOURCE
+	}
 	_, err := io.WriteString(hasher, textToHash)
 	if err != nil {
 		logger.Fatal("Failed to hash script value", logger.Args("error", err))

--- a/box/config_identifier_test.go
+++ b/box/config_identifier_test.go
@@ -21,7 +21,21 @@ func makeTestConfig() Configuration {
 // TestComputeIdentifier_StableForPypi is the regression guard for
 // "additive only, don't affect existing features". The expected value
 // was captured from the pre-git-support version of ComputeIdentifier
-// and must not change when GIT_SOURCE is empty.
+// and must not change when GIT_SOURCE is empty. If this hash changes,
+// existing deployed pypi/wheel binaries will fail to find their
+// installed package on next run — treat any change here as breaking.
+//
+// The hash is SHA1 of:
+//
+//	c.Package.Name + c.Package.Script + c.Package.Version.Static +
+//	  fmt.Sprintf("%t", c.AutoUpdateEnabled())
+//
+// For makeTestConfig() above: "my-package" + "my-script" + "1.0.0" + "true".
+// To regenerate after an intentional breaking change, run:
+//
+//	cfg := makeTestConfig()
+//	GIT_SOURCE = ""
+//	fmt.Println(cfg.ComputeIdentifier())
 func TestComputeIdentifier_StableForPypi(t *testing.T) {
 	// Ensure GIT_SOURCE is empty for this test (it's the default, but be explicit).
 	origGitSource := GIT_SOURCE

--- a/box/config_identifier_test.go
+++ b/box/config_identifier_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+)
+
+// makeTestConfig returns a Configuration representative of a typical pypi build.
+func makeTestConfig() Configuration {
+	return Configuration{
+		Package: PackageConfiguration{
+			Name:   "my-package",
+			Script: "my-script",
+			Version: PackageVersionConfiguration{
+				AutoUpdate: true,
+				Static:     "1.0.0",
+			},
+		},
+	}
+}
+
+// TestComputeIdentifier_StableForPypi is the regression guard for
+// "additive only, don't affect existing features". The expected value
+// was captured from the pre-git-support version of ComputeIdentifier
+// and must not change when GIT_SOURCE is empty.
+func TestComputeIdentifier_StableForPypi(t *testing.T) {
+	// Ensure GIT_SOURCE is empty for this test (it's the default, but be explicit).
+	origGitSource := GIT_SOURCE
+	GIT_SOURCE = ""
+	t.Cleanup(func() { GIT_SOURCE = origGitSource })
+
+	cfg := makeTestConfig()
+	got := cfg.ComputeIdentifier()
+	want := "my-package-30bb8d607d1417531f6df2a733f8ad02439c2b3a"
+	if got != want {
+		t.Fatalf("ComputeIdentifier() = %q, want %q (regression: existing pypi/wheel binaries must hash identically)", got, want)
+	}
+}
+
+func TestComputeIdentifier_DiffersByGitSource(t *testing.T) {
+	cfg := makeTestConfig()
+
+	origGitSource := GIT_SOURCE
+	t.Cleanup(func() { GIT_SOURCE = origGitSource })
+
+	GIT_SOURCE = ""
+	pypiID := cfg.ComputeIdentifier()
+
+	GIT_SOURCE = "git+https://github.com/org/repo"
+	gitID := cfg.ComputeIdentifier()
+
+	if pypiID == gitID {
+		t.Fatalf("expected git build to produce a different identifier than pypi build, both got %q", pypiID)
+	}
+}
+
+func TestComputeIdentifier_DiffersByGitRef(t *testing.T) {
+	cfg := makeTestConfig()
+
+	origGitSource := GIT_SOURCE
+	t.Cleanup(func() { GIT_SOURCE = origGitSource })
+
+	GIT_SOURCE = "git+https://github.com/org/repo@main"
+	mainID := cfg.ComputeIdentifier()
+
+	GIT_SOURCE = "git+https://github.com/org/repo@v1.0.0"
+	tagID := cfg.ComputeIdentifier()
+
+	if mainID == tagID {
+		t.Fatalf("expected different git refs to produce different identifiers, both got %q", mainID)
+	}
+}

--- a/box/generate.go
+++ b/box/generate.go
@@ -12,6 +12,7 @@ var CONFIGURATION_FILENAME = "uvbox.toml"
 var CERTIFICATES_BUNDLE_FILENAME = "ca-bundle.crt"
 var WHEELS_FOLDER = "wheels"
 var WHEELS_PLACEHOLDER = filepath.Join(WHEELS_FOLDER, "placeholder")
+var GIT_SOURCE_FILENAME = "git_source.txt"
 
 func deleteIfExists(filename string) {
 	if _, err := os.Stat(filename); err != nil && os.IsNotExist(err) {
@@ -50,4 +51,8 @@ func main() {
 
 	// Generate wheels folder placeholder
 	generateEmptyFileIfMissing(WHEELS_PLACEHOLDER)
+
+	// Generate empty git_source.txt placeholder (populated at uvbox-build
+	// time by boxer's writeGitSourceFile when `uvbox git <spec>` is used).
+	generateEmptyFileIfMissing(GIT_SOURCE_FILENAME)
 }

--- a/boxer/git.go
+++ b/boxer/git.go
@@ -2,33 +2,48 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
 // buildGoBuildLdflags constructs the ldflags string passed to `go build`
 // via the `GOFLAGS=-ldflags=...` environment variable. Pure function:
 // no side effects, no package-level state reads, so it can be unit-tested
-// without invoking go build. The arguments mirror the inputs the caller
-// has at the point of invocation (gitSource CLI arg, WheelsToEmbed list).
+// without invoking go build.
 //
 // Behavior:
 //   - Always includes "-s -w" to strip debug info.
 //   - If wheels are embedded, adds "-X main.INSTALL_WHEELS=yes" (unchanged
 //     from the pre-git-support behavior — regression test locks this in).
-//   - If a git source is set, adds "-X main.GIT_SOURCE=<spec>".
 //
-// The git and wheel flags are independent: validateGitSource + CLI command
-// separation ensure only one of the two is actually set in practice. This
-// function does not enforce mutual exclusion; the CLI layer does.
-func buildGoBuildLdflags(gitSource string, wheelsToEmbed []string) string {
+// Note on git source: unlike wheels, the git source is NOT injected via
+// ldflags. Go's GOFLAGS parser (strings.Fields) does not support spaces
+// inside flag values, so `-X main.GIT_SOURCE=<spec>` breaks parsing for
+// any ldflag string containing `-X`. Instead, the git source is written
+// to box/git_source.txt and embedded via //go:embed — see
+// writeGitSourceFile below and box/box_package_git.go.
+func buildGoBuildLdflags(wheelsToEmbed []string) string {
 	ldflags := "-s -w"
 	if len(wheelsToEmbed) > 0 {
 		ldflags += " -X main.INSTALL_WHEELS=yes"
 	}
-	if gitSource != "" {
-		ldflags += fmt.Sprintf(" -X main.GIT_SOURCE=%s", gitSource)
-	}
 	return ldflags
+}
+
+// writeGitSourceFile writes the provided git source string to
+// <boxRepository>/git_source.txt, which is embedded into the compiled
+// binary via //go:embed in box/box_package_git.go. The file is always
+// written (even with an empty string) to satisfy the go:embed directive,
+// which requires the target file to exist at build time. An empty file
+// means "not a git build"; a non-empty file means "git build, this is
+// the spec to pass to uv tool install --from".
+func writeGitSourceFile(boxRepository, gitSource string) error {
+	target := filepath.Join(boxRepository, "git_source.txt")
+	if err := os.WriteFile(target, []byte(gitSource), 0644); err != nil {
+		return fmt.Errorf("failed to write git source file to %s: %w", target, err)
+	}
+	return nil
 }
 
 // validateGitSource is called from preRun when a GitSource CLI argument

--- a/boxer/git.go
+++ b/boxer/git.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// buildGoBuildLdflags constructs the ldflags string passed to `go build`
+// via the `GOFLAGS=-ldflags=...` environment variable. Pure function:
+// no side effects, no package-level state reads, so it can be unit-tested
+// without invoking go build. The arguments mirror the inputs the caller
+// has at the point of invocation (gitSource CLI arg, WheelsToEmbed list).
+//
+// Behavior:
+//   - Always includes "-s -w" to strip debug info.
+//   - If wheels are embedded, adds "-X main.INSTALL_WHEELS=yes" (unchanged
+//     from the pre-git-support behavior — regression test locks this in).
+//   - If a git source is set, adds "-X main.GIT_SOURCE=<spec>".
+//
+// The git and wheel flags are independent: validateGitSource + CLI command
+// separation ensure only one of the two is actually set in practice. This
+// function does not enforce mutual exclusion; the CLI layer does.
+func buildGoBuildLdflags(gitSource string, wheelsToEmbed []string) string {
+	ldflags := "-s -w"
+	if len(wheelsToEmbed) > 0 {
+		ldflags += " -X main.INSTALL_WHEELS=yes"
+	}
+	if gitSource != "" {
+		ldflags += fmt.Sprintf(" -X main.GIT_SOURCE=%s", gitSource)
+	}
+	return ldflags
+}
+
+// validateGitSource is called from preRun when a GitSource CLI argument
+// was provided. It enforces the only format constraint we validate in
+// uvbox: the spec must begin with "git+". Everything else is delegated
+// to uv, which surfaces malformed specs loudly on first run of the
+// generated binary.
+func validateGitSource(gitSource string) error {
+	if gitSource == "" {
+		return fmt.Errorf("git source must not be empty")
+	}
+	if !strings.HasPrefix(gitSource, "git+") {
+		return fmt.Errorf("git source must start with 'git+' (e.g. git+https://github.com/org/repo), got %q", gitSource)
+	}
+	return nil
+}

--- a/boxer/git.go
+++ b/boxer/git.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,11 +19,11 @@ import (
 //     from the pre-git-support behavior — regression test locks this in).
 //
 // Note on git source: unlike wheels, the git source is NOT injected via
-// ldflags. Go's GOFLAGS parser (strings.Fields) does not support spaces
-// inside flag values, so `-X main.GIT_SOURCE=<spec>` breaks parsing for
-// any ldflag string containing `-X`. Instead, the git source is written
-// to box/git_source.txt and embedded via //go:embed — see
-// writeGitSourceFile below and box/box_package_git.go.
+// ldflags. The Go toolchain splits GOFLAGS on whitespace, so any ldflag
+// string containing `-X main.FOO=bar` is broken across flag boundaries
+// and the toolchain rejects `-X` as an unknown top-level flag. Instead,
+// the git source is written to box/git_source.txt and embedded via
+// //go:embed — see writeGitSourceFile below and box/box_package_git.go.
 func buildGoBuildLdflags(wheelsToEmbed []string) string {
 	ldflags := "-s -w"
 	if len(wheelsToEmbed) > 0 {
@@ -47,10 +48,16 @@ func writeGitSourceFile(boxRepository, gitSource string) error {
 }
 
 // validateGitSource is called from preRun when a GitSource CLI argument
-// was provided. It enforces the only format constraint we validate in
-// uvbox: the spec must begin with "git+". Everything else is delegated
-// to uv, which surfaces malformed specs loudly on first run of the
-// generated binary.
+// was provided. It enforces the uvbox-side format constraints so that
+// obvious typos fail at build time rather than on every end-user machine:
+//
+//   - must begin with "git+"
+//   - the URL after the "git+" prefix must parse
+//   - scheme must be one of http, https, ssh, file
+//   - non-file schemes must have a host
+//
+// Semantic ref resolution (branch, tag, commit existence) is still
+// delegated to uv on first run of the generated binary.
 func validateGitSource(gitSource string) error {
 	if gitSource == "" {
 		return fmt.Errorf("git source must not be empty")
@@ -58,5 +65,37 @@ func validateGitSource(gitSource string) error {
 	if !strings.HasPrefix(gitSource, "git+") {
 		return fmt.Errorf("git source must start with 'git+' (e.g. git+https://github.com/org/repo), got %q", gitSource)
 	}
+
+	raw := strings.TrimPrefix(gitSource, "git+")
+	if raw == "" {
+		return fmt.Errorf("git source is missing a URL after 'git+' prefix, got %q", gitSource)
+	}
+
+	// Strip an optional trailing "@ref" before URL parsing, but only when
+	// the `@` is not part of a userinfo segment like "ssh://git@host/...".
+	// Any `@` appearing after the first `/` of the path component is an
+	// "@ref" suffix; userinfo `@` always precedes the host segment.
+	parseTarget := raw
+	if slash := strings.Index(raw, "/"); slash != -1 {
+		if at := strings.LastIndex(raw, "@"); at > slash {
+			parseTarget = raw[:at]
+		}
+	}
+
+	u, err := url.Parse(parseTarget)
+	if err != nil {
+		return fmt.Errorf("git source %q is not a valid URL: %w", gitSource, err)
+	}
+
+	switch u.Scheme {
+	case "http", "https", "ssh", "file":
+	default:
+		return fmt.Errorf("git source scheme %q is not supported; use http(s), ssh, or file (got %q)", u.Scheme, gitSource)
+	}
+
+	if u.Scheme != "file" && u.Host == "" {
+		return fmt.Errorf("git source %q is missing a host", gitSource)
+	}
+
 	return nil
 }

--- a/boxer/git_test.go
+++ b/boxer/git_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildGoBuildLdflags_Pypi is a regression guard: the ldflag string
+// produced for a plain pypi build must match what goBuild used to produce
+// before git support was added.
+func TestBuildGoBuildLdflags_Pypi(t *testing.T) {
+	got := buildGoBuildLdflags("", nil)
+	want := "-s -w"
+	if got != want {
+		t.Fatalf("buildGoBuildLdflags pypi = %q, want %q", got, want)
+	}
+}
+
+// TestBuildGoBuildLdflags_Wheel is a regression guard for the wheel path.
+func TestBuildGoBuildLdflags_Wheel(t *testing.T) {
+	got := buildGoBuildLdflags("", []string{"some-wheel.whl"})
+	want := "-s -w -X main.INSTALL_WHEELS=yes"
+	if got != want {
+		t.Fatalf("buildGoBuildLdflags wheel = %q, want %q", got, want)
+	}
+}
+
+func TestBuildGoBuildLdflags_Git(t *testing.T) {
+	got := buildGoBuildLdflags("git+https://github.com/org/repo@main", nil)
+	if !strings.Contains(got, "-s -w") {
+		t.Errorf("expected base flags -s -w, got %q", got)
+	}
+	if !strings.Contains(got, "-X main.GIT_SOURCE=git+https://github.com/org/repo@main") {
+		t.Errorf("expected -X main.GIT_SOURCE, got %q", got)
+	}
+	if strings.Contains(got, "INSTALL_WHEELS") {
+		t.Errorf("git build must not set INSTALL_WHEELS, got %q", got)
+	}
+}
+
+// TestBuildGoBuildLdflags_GitDoesNotOmitOnWheels covers the edge case
+// where both inputs are set. CLI validation enforces mutual exclusion at
+// the command layer; this test just verifies the helper itself still emits
+// the git flag if both happen to be passed.
+func TestBuildGoBuildLdflags_GitDoesNotOmitOnWheels(t *testing.T) {
+	got := buildGoBuildLdflags("git+https://github.com/org/repo", []string{"some.whl"})
+	if !strings.Contains(got, "-X main.GIT_SOURCE=git+https://github.com/org/repo") {
+		t.Errorf("expected -X main.GIT_SOURCE in output, got %q", got)
+	}
+}

--- a/boxer/git_test.go
+++ b/boxer/git_test.go
@@ -1,15 +1,17 @@
 package main
 
 import (
-	"strings"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
 // TestBuildGoBuildLdflags_Pypi is a regression guard: the ldflag string
 // produced for a plain pypi build must match what goBuild used to produce
-// before git support was added.
+// before git support was added. Git support does NOT inject ldflags
+// (see boxer/git.go for why) so adding it must not change this output.
 func TestBuildGoBuildLdflags_Pypi(t *testing.T) {
-	got := buildGoBuildLdflags("", nil)
+	got := buildGoBuildLdflags(nil)
 	want := "-s -w"
 	if got != want {
 		t.Fatalf("buildGoBuildLdflags pypi = %q, want %q", got, want)
@@ -18,34 +20,42 @@ func TestBuildGoBuildLdflags_Pypi(t *testing.T) {
 
 // TestBuildGoBuildLdflags_Wheel is a regression guard for the wheel path.
 func TestBuildGoBuildLdflags_Wheel(t *testing.T) {
-	got := buildGoBuildLdflags("", []string{"some-wheel.whl"})
+	got := buildGoBuildLdflags([]string{"some-wheel.whl"})
 	want := "-s -w -X main.INSTALL_WHEELS=yes"
 	if got != want {
 		t.Fatalf("buildGoBuildLdflags wheel = %q, want %q", got, want)
 	}
 }
 
-func TestBuildGoBuildLdflags_Git(t *testing.T) {
-	got := buildGoBuildLdflags("git+https://github.com/org/repo@main", nil)
-	if !strings.Contains(got, "-s -w") {
-		t.Errorf("expected base flags -s -w, got %q", got)
+func TestWriteGitSourceFile_Empty(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeGitSourceFile(dir, ""); err != nil {
+		t.Fatalf("writeGitSourceFile empty failed: %v", err)
 	}
-	if !strings.Contains(got, "-X main.GIT_SOURCE=git+https://github.com/org/repo@main") {
-		t.Errorf("expected -X main.GIT_SOURCE, got %q", got)
+
+	got, err := os.ReadFile(filepath.Join(dir, "git_source.txt"))
+	if err != nil {
+		t.Fatalf("failed to read written file: %v", err)
 	}
-	if strings.Contains(got, "INSTALL_WHEELS") {
-		t.Errorf("git build must not set INSTALL_WHEELS, got %q", got)
+	if string(got) != "" {
+		t.Fatalf("expected empty file, got %q", string(got))
 	}
 }
 
-// TestBuildGoBuildLdflags_GitDoesNotOmitOnWheels covers the edge case
-// where both inputs are set. CLI validation enforces mutual exclusion at
-// the command layer; this test just verifies the helper itself still emits
-// the git flag if both happen to be passed.
-func TestBuildGoBuildLdflags_GitDoesNotOmitOnWheels(t *testing.T) {
-	got := buildGoBuildLdflags("git+https://github.com/org/repo", []string{"some.whl"})
-	if !strings.Contains(got, "-X main.GIT_SOURCE=git+https://github.com/org/repo") {
-		t.Errorf("expected -X main.GIT_SOURCE in output, got %q", got)
+func TestWriteGitSourceFile_WithSpec(t *testing.T) {
+	dir := t.TempDir()
+	spec := "git+https://github.com/org/repo@main"
+
+	if err := writeGitSourceFile(dir, spec); err != nil {
+		t.Fatalf("writeGitSourceFile failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "git_source.txt"))
+	if err != nil {
+		t.Fatalf("failed to read written file: %v", err)
+	}
+	if string(got) != spec {
+		t.Fatalf("expected %q, got %q", spec, string(got))
 	}
 }
 

--- a/boxer/git_test.go
+++ b/boxer/git_test.go
@@ -88,8 +88,10 @@ func TestValidateGitSource_AcceptsValidSpecs(t *testing.T) {
 		"git+https://github.com/org/repo@main",
 		"git+https://github.com/org/repo@v1.0.0",
 		"git+https://github.com/org/repo@abc123def456",
+		"git+https://github.com/org/repo@feature/new-thing",
 		"git+ssh://git@github.com/org/repo",
 		"git+ssh://git@github.com/org/repo@main",
+		"git+file:///tmp/repo",
 	}
 	for _, s := range cases {
 		t.Run(s, func(t *testing.T) {
@@ -98,4 +100,34 @@ func TestValidateGitSource_AcceptsValidSpecs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateGitSource_RejectsMalformed covers the deeper URL-parsing
+// checks: typos in scheme, missing host, prefix-only specs.
+func TestValidateGitSource_RejectsMalformed(t *testing.T) {
+	cases := []string{
+		"git+",                            // prefix only
+		"git+htps://github.com/org/repo",  // scheme typo
+		"git+ftp://github.com/org/repo",   // unsupported scheme
+		"git+https:///org/repo",           // no host
+		"git+https://",                    // no host, no path
+	}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			if err := validateGitSource(s); err == nil {
+				t.Fatalf("expected %q to be rejected, got nil", s)
+			}
+		})
+	}
+}
+
+// TestValidateGitSourceFlag_EmptyIsNoop guards the contract that pypi/wheel
+// builds (which leave GitSource empty) are never affected by the git
+// validation path. If this ever regresses, every pypi/wheel build breaks.
+func TestValidateGitSourceFlag_EmptyIsNoop(t *testing.T) {
+	orig := GitSource
+	t.Cleanup(func() { GitSource = orig })
+	GitSource = ""
+	// Must not call logger.Fatal.
+	validateGitSourceFlag()
 }

--- a/boxer/git_test.go
+++ b/boxer/git_test.go
@@ -48,3 +48,44 @@ func TestBuildGoBuildLdflags_GitDoesNotOmitOnWheels(t *testing.T) {
 		t.Errorf("expected -X main.GIT_SOURCE in output, got %q", got)
 	}
 }
+
+func TestValidateGitSource_Empty(t *testing.T) {
+	if err := validateGitSource(""); err == nil {
+		t.Fatal("expected error for empty git source, got nil")
+	}
+}
+
+func TestValidateGitSource_MissingGitPrefix(t *testing.T) {
+	cases := []string{
+		"https://github.com/org/repo",
+		"http://github.com/org/repo",
+		"github.com/org/repo",
+		"ssh://git@github.com/org/repo",
+		"file:///tmp/repo",
+	}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			if err := validateGitSource(s); err == nil {
+				t.Fatalf("expected error for %q, got nil", s)
+			}
+		})
+	}
+}
+
+func TestValidateGitSource_AcceptsValidSpecs(t *testing.T) {
+	cases := []string{
+		"git+https://github.com/org/repo",
+		"git+https://github.com/org/repo@main",
+		"git+https://github.com/org/repo@v1.0.0",
+		"git+https://github.com/org/repo@abc123def456",
+		"git+ssh://git@github.com/org/repo",
+		"git+ssh://git@github.com/org/repo@main",
+	}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			if err := validateGitSource(s); err != nil {
+				t.Fatalf("expected %q to be valid, got error: %v", s, err)
+			}
+		})
+	}
+}

--- a/boxer/main.go
+++ b/boxer/main.go
@@ -249,6 +249,13 @@ func insertFilesIntoBoxRepository(boxRepository string) error {
 		}
 	}
 
+	// Write the git source file (always — empty for pypi/wheel builds,
+	// populated for `uvbox git <spec>` builds). See boxer/git.go and
+	// box/box_package_git.go for the embed mechanism.
+	if err := writeGitSourceFile(boxRepository, GitSource); err != nil {
+		return fmt.Errorf("failed to write git source file: %w", err)
+	}
+
 	return nil
 }
 
@@ -370,7 +377,9 @@ func goBuild(repository, buildName, platform, arch string) error {
 	var outbuf, errbuf strings.Builder
 
 	// Compilation flag — see boxer/git.go for the pure helper and its tests.
-	ldflags := buildGoBuildLdflags(GitSource, WheelsToEmbed)
+	// Git source is NOT injected via ldflags (Go's GOFLAGS parser rejects
+	// `-X main.FOO=bar`); it is embedded via box/git_source.txt instead.
+	ldflags := buildGoBuildLdflags(WheelsToEmbed)
 
 	// Command
 	cmd := exec.Command("go", "build", "-o", buildName)

--- a/boxer/main.go
+++ b/boxer/main.go
@@ -197,8 +197,13 @@ func validateGitSourceFlag() {
 	if GitSource == "" {
 		return
 	}
+	if len(WheelsToEmbed) > 0 {
+		logger.Fatal("cannot combine a git source with embedded wheels; use either `uvbox git` or `uvbox wheel`, not both")
+	}
 	if err := validateGitSource(GitSource); err != nil {
-		logger.Fatal("invalid git source", logger.Args("error", err))
+		logger.Fatal("invalid git source argument",
+			logger.Args("error", err, "providedValue", GitSource,
+				"hint", "expected form: git+https://host/org/repo[@ref] or git+ssh://git@host/org/repo[@ref]"))
 	}
 }
 
@@ -249,9 +254,7 @@ func insertFilesIntoBoxRepository(boxRepository string) error {
 		}
 	}
 
-	// Write the git source file (always — empty for pypi/wheel builds,
-	// populated for `uvbox git <spec>` builds). See boxer/git.go and
-	// box/box_package_git.go for the embed mechanism.
+	// Always write — see writeGitSourceFile.
 	if err := writeGitSourceFile(boxRepository, GitSource); err != nil {
 		return fmt.Errorf("failed to write git source file: %w", err)
 	}
@@ -376,9 +379,8 @@ func goGenerate(repository, platform, arch string) error {
 func goBuild(repository, buildName, platform, arch string) error {
 	var outbuf, errbuf strings.Builder
 
-	// Compilation flag — see boxer/git.go for the pure helper and its tests.
-	// Git source is NOT injected via ldflags (Go's GOFLAGS parser rejects
-	// `-X main.FOO=bar`); it is embedded via box/git_source.txt instead.
+	// See buildGoBuildLdflags in boxer/git.go for why git source is not
+	// injected via ldflags.
 	ldflags := buildGoBuildLdflags(WheelsToEmbed)
 
 	// Command

--- a/boxer/main.go
+++ b/boxer/main.go
@@ -31,6 +31,7 @@ var Config string
 var Output string
 var Nfpm string
 var ReleaseVersion string
+var GitSource string
 
 var Darwin bool
 var Linux bool
@@ -104,6 +105,35 @@ func main() {
 	wheelCmd.Flags().BoolVarP(&Amd, "amd", "", false, "Build for AMD64")
 	wheelCmd.Flags().BoolVarP(&Arm, "arm", "", false, "build for ARM64")
 
+	// UVBOX GIT
+	var gitCmd = &cobra.Command{
+		Use:   "git <git-spec>",
+		Short: "Use a git repository as package source to generate a standalone executable",
+		Long: "Use a git repository as package source to generate a standalone executable.\n\n" +
+			"The git spec is passed through to `uv tool install --from` verbatim.\n" +
+			"Examples:\n" +
+			"  uvbox git git+https://github.com/org/repo\n" +
+			"  uvbox git git+https://github.com/org/repo@main\n" +
+			"  uvbox git git+https://github.com/org/repo@v1.0.0",
+		Args: cobra.ExactArgs(1),
+		PreRun: func(cmd *cobra.Command, args []string) {
+			GitSource = args[0]
+			preRun()
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := run(); err != nil {
+				logger.Fatal("failed to run git command", logger.Args("error", err))
+			}
+		},
+	}
+	gitCmd.Flags().StringVarP(&Config, "config", "c", "", "Configuration file")
+	gitCmd.Flags().StringVarP(&Output, "output", "o", "dist", "Output directory")
+	gitCmd.Flags().BoolVarP(&Darwin, "darwin", "d", false, "Build for darwin")
+	gitCmd.Flags().BoolVarP(&Linux, "linux", "l", false, "Build for linux")
+	gitCmd.Flags().BoolVarP(&Windows, "windows", "w", false, "Build for windows")
+	gitCmd.Flags().BoolVarP(&Amd, "amd", "", false, "Build for AMD64")
+	gitCmd.Flags().BoolVarP(&Arm, "arm", "", false, "build for ARM64")
+
 	// UVBOX
 	var rootCmd = &cobra.Command{
 		Use:   "uvbox",
@@ -112,6 +142,7 @@ func main() {
 	}
 	rootCmd.AddCommand(pypiCmd)
 	rootCmd.AddCommand(wheelCmd)
+	rootCmd.AddCommand(gitCmd)
 	rootCmd.PersistentFlags().StringVarP(&ReleaseVersion, "release-version", "", "0.0.0", "Specify a version for the binaries. Will be used for example for versioning linux packages.")
 	rootCmd.PersistentFlags().BoolVarP(&NoBanner, "no-banner", "", false, "Do not display the banner")
 	rootCmd.PersistentFlags().StringVarP(&Nfpm, "nfpm", "", "", "Generate linux packages with the given nfpm configuration file")
@@ -127,6 +158,7 @@ func preRun() {
 	validateGoAvailability()
 	validateNfpmAvailability()
 	validateWheelsToEmbed()
+	validateGitSourceFlag()
 }
 
 func validateOutputDirectoryFlag() {
@@ -158,6 +190,15 @@ func validateWheelsToEmbed() {
 		} else if !ok {
 			logger.Fatal("wheel should be an existing file", logger.Args("path", wheel))
 		}
+	}
+}
+
+func validateGitSourceFlag() {
+	if GitSource == "" {
+		return
+	}
+	if err := validateGitSource(GitSource); err != nil {
+		logger.Fatal("invalid git source", logger.Args("error", err))
 	}
 }
 
@@ -328,11 +369,8 @@ func goGenerate(repository, platform, arch string) error {
 func goBuild(repository, buildName, platform, arch string) error {
 	var outbuf, errbuf strings.Builder
 
-	// Compilation flag
-	ldflags := "-s -w"
-	if len(WheelsToEmbed) > 0 {
-		ldflags += " -X main.INSTALL_WHEELS=yes"
-	}
+	// Compilation flag — see boxer/git.go for the pure helper and its tests.
+	ldflags := buildGoBuildLdflags(GitSource, WheelsToEmbed)
 
 	// Command
 	cmd := exec.Command("go", "build", "-o", buildName)

--- a/examples/git/simple-app.toml
+++ b/examples/git/simple-app.toml
@@ -1,7 +1,7 @@
 # Build a uvbox binary from a git repository.
 #
 # Usage:
-#   uvbox git git+https://github.com/<org>/<repo> --config examples/git/simple-app.toml
+#   uvbox git git+https://github.com/VaasuDevanS/cowsay-python --config examples/git/simple-app.toml
 #
 # The git spec is passed through to `uv tool install --from` at runtime, so
 # any form uv accepts works: @main, @v1.0.0, @<commit-sha>, ssh:// URLs, etc.
@@ -11,10 +11,9 @@
 # [package].script must match an entry from the package's [project.scripts].
 
 [package]
-name = "my-app"
-script = "my-app"
+name = "cowsay"
+script = "cowsay"
 
-# To re-resolve the git ref on every run (equivalent to pycrucible's
-# delete_after_run=true), uncomment:
+# To re-resolve the git ref on every run, uncomment:
 # [package.version]
 # auto-update = true

--- a/examples/git/simple-app.toml
+++ b/examples/git/simple-app.toml
@@ -1,0 +1,20 @@
+# Build a uvbox binary from a git repository.
+#
+# Usage:
+#   uvbox git git+https://github.com/<org>/<repo> --config examples/git/simple-app.toml
+#
+# The git spec is passed through to `uv tool install --from` at runtime, so
+# any form uv accepts works: @main, @v1.0.0, @<commit-sha>, ssh:// URLs, etc.
+#
+# [package].name must match the distribution name the package registers
+# (what `uv tool list` reports after installation).
+# [package].script must match an entry from the package's [project.scripts].
+
+[package]
+name = "my-app"
+script = "my-app"
+
+# To re-resolve the git ref on every run (equivalent to pycrucible's
+# delete_after_run=true), uncomment:
+# [package.version]
+# auto-update = true


### PR DESCRIPTION
Closes #19.

## Summary

Adds a new `uvbox git <git-spec>` subcommand alongside the existing `pypi` and `wheel` source types. The git spec is passed through to `uv tool install --from` verbatim, so any form `uv` accepts works (`@main`, `@v1.0.0`, `@<commit>`, `ssh://`, etc.).

```bash
uvbox git git+https://github.com/org/repo
uvbox git git+https://github.com/org/repo@v1.0.0
uvbox git git+ssh://git@github.com/org/private-repo
```

Implements the approach @Coruscant11 chose in [this comment](https://github.com/AmadeusITGroup/uvbox/issues/19#issuecomment-4222876492): subcommand with the git spec as a positional CLI argument, no changes to the `uvbox.toml` schema.

When the outer version check decides to install/update, `uvToolInstallGit` runs `uv tool install --from <spec> <name> --upgrade`. `auto-update = true` with no `[package.version]` set re-enters that path on every run (the version compare treats the unset case as always-stale), delivering the `pycrucible delete_after_run`-equivalent behavior the issue requested. If a user sets `[package.version].static` on a git build, a user-visible warning is logged because the git ref is the source of truth.

## Design notes

- **Additive only.** The pypi and wheel leaf install functions are untouched. A regression test in `box/config_identifier_test.go` locks in a byte-stable golden hash for `ComputeIdentifier` to guarantee existing binaries find the same XDG dir.
- **Distinct identifier per git source.** The git spec participates in `ComputeIdentifier` (only when set), so binaries built from `git+url@main` and `git+url@v1.0.0` get separate isolated install dirs. No cross-contamination with pypi-built binaries of the same package.
- **Source embedding via file, not ldflag.** See "Pre-existing bug discovered" below.
- **Validation:** must start with `git+`, the URL after the prefix must parse, the scheme must be one of `http`/`https`/`ssh`/`file`, and non-file schemes must have a host. Semantic ref resolution (branch/tag/commit existence) is still delegated to `uv` on first run.
- **Git and embedded wheels are mutually exclusive.** Enforced both at build time (`boxer` preRun) and runtime (pure `selectInstallMethod` helper in `box/box_package.go` returns an error when both `GIT_SOURCE` and `INSTALL_WHEELS` are set).

## Pre-existing bug discovered (and worked around)

The original spec proposed embedding the git source via `-ldflags "-X main.GIT_SOURCE=..."`. The smoke test surfaced that this **does not work** because of a pre-existing bug introduced in #14 (commit f19680f, "fix: Use environment variables for ldflags"):

> The Go toolchain splits `GOFLAGS` on whitespace. Any ldflag string containing `-X main.foo=bar` is split across flag boundaries, and the toolchain rejects `-X` as an unknown top-level flag with `go: parsing $GOFLAGS: unknown flag -X`.

This silently broke the **`uvbox wheel` path** in main since #14 was merged — it sets `-X main.INSTALL_WHEELS=yes`, which fails the same way. No test exercises wheel mode end-to-end so nobody noticed. Reproduction:

```bash
GOFLAGS='-ldflags=-s -w -X main.INSTALL_WHEELS=yes' go build -o hello .
# go: parsing $GOFLAGS: unknown flag -X
```

**This PR does not fix the wheel bug** — touching it requires re-validating the original Windows-via-uvx fix from #14 on Windows, which is out of scope here. The wheel path remains broken in main and should be addressed in a separate PR.

For git, this PR sidesteps GOFLAGS entirely by embedding the source in a small file (`box/git_source.txt`) read at compile time via `//go:embed`. boxer's `writeGitSourceFile` writes the spec into this file before `go build`. Empty file = pypi/wheel build, non-empty = git build. Same end result, different transport.

## Files

**Runtime (`box/`):**
- `box/box_package_git.go` (new) — `GIT_SOURCE` (loaded from embedded `git_source.txt`), `uvToolInstallGit` (accepts `packageVersion` for signature parity, warns and drops it since the git ref is authoritative; captures `uv` stdout into the returned error on failure), `buildUvToolInstallFromArgs` pure helper
- `box/box_package.go` — pure `selectInstallMethod(gitSource, installWheels)` helper dispatches to pypi/wheels/git; rejects the git+wheels combination at runtime. `InstallPackage` now propagates `downloadTemporaryFile` errors instead of swallowing them at `Debug` level (pre-existing silent failure fixed while on the hot path)
- `box/config.go` — `ComputeIdentifier` conditionally appends `GIT_SOURCE` (no-op when empty)
- `box/generate.go` — adds empty `git_source.txt` placeholder generation, mirroring the existing `wheels/placeholder` pattern
- `box/config_identifier_test.go` (new) — golden-hash regression test (with regeneration recipe) + git distinction tests
- `box/box_package_git_test.go` (new) — pure-helper command-shape tests
- `box/box_package_test.go` (new) — `TestSelectInstallMethod` dispatch matrix (pypi/wheels/git × default/conflict)

**Build-time (`boxer/`):**
- `boxer/git.go` (new) — `buildGoBuildLdflags` pure helper (without git, since git uses file embed), `validateGitSource` (URL-parsing, scheme whitelist, host check), `writeGitSourceFile`
- `boxer/main.go` — new `gitCmd` cobra command, `GitSource` CLI var, `validateGitSourceFlag` in preRun (also enforces mutual exclusion with `WheelsToEmbed` and prints helpful hints on invalid input), `writeGitSourceFile` call in `insertFilesIntoBoxRepository`
- `boxer/git_test.go` (new) — ldflag regression tests for pypi/wheel, `writeGitSourceFile` tests, `validateGitSource` positive cases, `TestValidateGitSource_RejectsMalformed` (scheme typos, prefix-only, missing host), `TestValidateGitSourceFlag_EmptyIsNoop` (guards the "pypi/wheel builds unaffected" contract)

**Docs:**
- `README.md` — feature bullet updated, new "Build from a Git Repository" section, behavior of `[package.version]` for git builds, private repo auth note, runtime `git` requirement
- `examples/git/simple-app.toml` (new) — minimal runnable example using `VaasuDevanS/cowsay-python`
- `.gitignore` — adds `box/git_source.txt`

## Test Plan

- [x] Full `box` test suite passes (`go test ./...`) including the `ComputeIdentifier` golden-hash regression guard and the new `selectInstallMethod` dispatch matrix
- [x] Full `boxer` test suite passes including ldflag regression guards for the existing pypi/wheel paths and the new `validateGitSource` URL-parsing cases
- [x] `go vet ./...` clean in both modules
- [x] Manual smoke test: `uvbox git git+https://github.com/VaasuDevanS/cowsay-python --darwin --arm` builds, the resulting binary runs end-to-end (`./cowsay -t "hi"` prints the cow), `self update` reports "Already up-to-date", `self path` shows a git-distinct identifier
- [x] Regression: `uvbox pypi` still works, produces a different identifier hash (separate XDG dir from the git build of the same package)

Reviewers can reproduce the smoke test using the committed example config:

```bash
# Build boxer from source
cd boxer && go generate && go build -o /tmp/uvbox . && cd ..

# Build a cowsay binary straight from the git repo using the example config
/tmp/uvbox git git+https://github.com/VaasuDevanS/cowsay-python \
    --config examples/git/simple-app.toml \
    --darwin --arm   # adjust --darwin/--linux/--windows and --arm/--amd to your host

# Run the produced artifact
cd dist && tar xzf cowsay-*.tar.gz && ./cowsay -t "git works!"
```

See [`examples/git/simple-app.toml`](./examples/git/simple-app.toml) for the config, including the commented-out `[package.version] auto-update = true` block that flips the binary into "always re-resolve the git ref on every run" mode.

## Update — review round 1 (commit a38fe58)

Addressed findings from a multi-agent PR review pass. All changes are additive to the original design:

- **Propagate constraints-file download error** (pre-existing silent failure in `InstallPackage`, now on the git hot path)
- **Reject `GIT_SOURCE + INSTALL_WHEELS` conflict** at build time (boxer preRun) and runtime (`selectInstallMethod`)
- **Warn when `[package.version]` is set on a git build** — `uvToolInstallGit` logs `logger.Warn` instead of silently ignoring
- **Capture `uv` stdout into error messages** on git install failure, so resolver/auth output isn't discarded
- **Deepen `validateGitSource`** with `net/url` parsing — reject scheme typos, unsupported schemes, and missing hosts at build time instead of on end-user machines
- **New tests**: `box/box_package_test.go` (dispatch matrix) and expanded `boxer/git_test.go` (malformed-spec cases + empty-flag no-op guard)
- **Doc reconciliation**: README `[package.version]` section, golden-hash regeneration recipe, trimmed duplicated inline comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
